### PR TITLE
rules: exclude modules that are not loaded and pull extra deps

### DIFF
--- a/debian/asterisk.dirs
+++ b/debian/asterisk.dirs
@@ -1,5 +1,4 @@
 etc/asterisk
-run/asterisk
 usr/share/asterisk
 usr/share/asterisk/firmware/iax
 var/lib/asterisk

--- a/debian/asterisk.lintian-overrides
+++ b/debian/asterisk.lintian-overrides
@@ -2,3 +2,5 @@
 asterisk: binary-without-manpage usr/sbin/astcanary
 # private copy of pjproject
 asterisk: non-dev-pkg-with-shlib-symlink usr/lib/libasteriskpj.so.2 usr/lib/libasteriskpj.so
+# Ignore the included jquery in mantest.html
+asterisk: privacy-breach-uses-embedded-file var/lib/asterisk/static-http/mantest.html You may use the libjs-jquery package. (http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js)

--- a/debian/asterisk.lintian-overrides
+++ b/debian/asterisk.lintian-overrides
@@ -1,0 +1,4 @@
+# astcanary is not supposed to be invoked manually
+asterisk: binary-without-manpage usr/sbin/astcanary
+# private copy of pjproject
+asterisk: non-dev-pkg-with-shlib-symlink usr/lib/libasteriskpj.so.2 usr/lib/libasteriskpj.so

--- a/debian/asterisk.service
+++ b/debian/asterisk.service
@@ -6,6 +6,7 @@ Before=monit.service
 
 [Service]
 Type=forking
+RuntimeDirectory=asterisk
 ExecStart=/usr/sbin/asterisk -g -U asterisk
 ExecStartPost=/bin/bash -c 'for i in {1..10}; do /usr/sbin/asterisk -rx "core waitfullybooted" &>/dev/null && exit 0; sleep 1; done; exit 1'
 ExecReload=/usr/sbin/asterisk -rx 'core reload'

--- a/debian/changelog
+++ b/debian/changelog
@@ -911,7 +911,7 @@ asterisk (8:13.7.0-1~xivo3) xivo-dev; urgency=medium
 
   * revert 434db4dd427543102443cb555416e35295016bb fix on asterisk 13.8 not 13.7
 
- -- Sylvain Boily <quintana@quintana>  Tue, 19 Jan 2016 14:30:49 -0500
+ -- Sylvain Boily <sylvain@wazo.io>  Tue, 19 Jan 2016 14:30:49 -0500
 
 asterisk (8:13.7.0-1~xivo1) xivo-dev; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:16.6.1-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * remove the openr2 dependency from the binary package
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 06 Nov 2019 14:02:47 -0500
+
 asterisk (8:16.6.1-1~wazo2) wazo-dev-buster; urgency=medium
 
   * upgrade to Asterisk 16.6.1

--- a/debian/control
+++ b/debian/control
@@ -71,6 +71,7 @@ Breaks:
  wazo-res-stasis-amqp (<< 17.14~),
  xivo-libsccp (<< 17.14~),
  xivo-res-freeze-check (<< 17.14~)
+Homepage: http://www.asterisk.org
 Description: Open Source Private Branch Exchange (PBX) - Wazo version
  Asterisk is an Open Source PBX and telephony toolkit.  It is, in a
  sense, middleware between Internet and telephony channels on the bottom,
@@ -95,8 +96,6 @@ Description: Open Source Private Branch Exchange (PBX) - Wazo version
  This software was heavily patched by Debian and Wazo.
  .
  This Debian package contains the classic Asterisk binary.
- .
-  Homepage: http://www.asterisk.org.
 
 Package: asterisk-dbg
 Architecture: any
@@ -106,6 +105,7 @@ Replaces: asterisk11-dbg
 Conflicts: asterisk11-dbg
 Provides: asterisk11-dbg
 Depends: ${misc:Depends}, asterisk (= ${binary:Version})
+Homepage: http://www.asterisk.org
 Description: Open Source Private Branch Exchange (PBX) - Wazo version
  Asterisk is an Open Source PBX and telephony toolkit.  It is, in a
  sense, middleware between Internet and telephony channels on the bottom,
@@ -130,14 +130,13 @@ Description: Open Source Private Branch Exchange (PBX) - Wazo version
  This software was heavily patched by Debian and Wazo.
  .
  This package contains gdb debugging symbols for the classic Asterisk binary.
- .
-  Homepage: http://www.asterisk.org.
 
 Package: asterisk-dev
 Architecture: all
 Recommends: asterisk
 Section: devel
 Depends: ${misc:Depends}
+Homepage: http://www.asterisk.org
 Description: development files for asterisk
  Asterisk is an Open Source PBX and telephony toolkit.  It is, in a
  sense, middleware between Internet and telephony channels on the bottom,
@@ -163,14 +162,13 @@ Description: development files for asterisk
  .
  This package contains the include files used if you wish to compile a
  package which requires asterisk source file headers.
- .
-  Homepage: http://www.asterisk.org.
 
 Package: asterisk-doc
 Architecture: all
 Recommends: asterisk
 Section: doc
 Depends: ${misc:Depends}
+Homepage: http://www.asterisk.org
 Description: Source code documentation for Asterisk
  Asterisk is an Open Source PBX and telephony toolkit.
  .
@@ -196,14 +194,13 @@ Description: Source code documentation for Asterisk
   * QuickNet Internet PhoneJack and LineJack (http://www.quicknet.net)
  .
   This package contains the documentation for configuring an Asterisk system.
- .
-  Homepage: http://www.asterisk.org.
 
 Package: asterisk-sounds-main
 Architecture: all
 Enhances: asterisk
 Section: comm
 Depends: ${misc:Depends}
+Homepage: http://www.asterisk.org
 Description: sound files for asterisk
  Asterisk is an Open Source PBX and telephony toolkit.  It is, in a
  sense, middleware between Internet and telephony channels on the bottom,
@@ -228,5 +225,3 @@ Description: sound files for asterisk
  This software was heavily patched by Debian and Wazo.
  .
  This package contains the default sound files for operation of asterisk
- .
-  Homepage: http://www.asterisk.org.

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/autotools.mk
 
 DEB_SHLIBDEPS_INCLUDE := $(CURDIR)/debian/tmp/usr/lib
-DEB_DH_SHLIBDEPS_ARGS_ALL += -u--ignore-missing-info
+DEB_DH_SHLIBDEPS_ARGS_ALL += -u--ignore-missing-info -Xchan_also -Xchan_console -Xchan_dahdi -Xchan_mgcp -Xchan_oss -Xchan_phone -Xchan_sip -Xchan_skinny -Xchan_unistim -Xchan_motif -Xres_xmpp -Xcdr_radius -Xcdr_tds -Xcdr_pgsql -Xcel_radius -Xcel_tds -Xapp_jack -Xres_calendat -Xres_calendar_caldav -Xres_calendar_ews -Xres_calendar_exchange -Xres_calendar_icalendar -Xres_xmpp -Xres_snmp
 DEB_MAKE_INVOKE = $(DEB_MAKE_ENVVARS) $(MAKE) -C $(DEB_BUILDDIR)
 BUILD_TREE = .
 


### PR DESCRIPTION
these modules are not loaded by default with the Wazo configuration but the
dependencies are all pulled when installing Asterisk. This change removes those
explicit dependencies.

another package will be added to pull down all dependencies that will be
installed manually if one of them is used