### PR TITLE
fix a mistake in the changelog version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-asterisk (8:16.6.2-1~4) wazo-dev-buster; urgency=medium
+asterisk (8:16.6.2-1~wazo4) wazo-dev-buster; urgency=medium
 
   * add debug instructions for the vanilla and debug packages
 


### PR DESCRIPTION
I cannot leave ~4 because ~wazo3 is higher

```
dpkg --compare-versions "8:16.6.2-1~wazo3" "lt" "8:16.6.2-1~wazo4"
0
```
```
dpkg --compare-versions "8:16.6.2-1~wazo3" "lt" "8:16.6.2-1~4"
1
```