### PR TITLE
add User asterisk to asterisk.service

### DIFF
--- a/debian/asterisk.service
+++ b/debian/asterisk.service
@@ -12,6 +12,7 @@ ExecStartPost=/bin/bash -c 'for i in {1..10}; do /usr/sbin/asterisk -rx "core wa
 ExecReload=/usr/sbin/asterisk -rx 'core reload'
 PIDFile=/run/asterisk/asterisk.pid
 UMask=0007
+User=asterisk
 WorkingDirectory=/var/spool/asterisk
 
 LimitNOFILE=8192

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:16.8.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * add User asterisk to the service file
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 10 Feb 2020 14:30:19 -0500
+
 asterisk (8:16.8.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * add french core sounds


### PR DESCRIPTION
reason: new version of systemd (241-7~deb10u3) add a commit:

* core: change ownership/mode of the execution directories also for
static users