### PR TITLE
asterisk-doc: add the JSON extracted version of the PJSIP doc

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:16.8.0-1~wazo4) wazo-dev-buster; urgency=medium
+
+  * add a JSON version of the PJSIP doc
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 12 Feb 2020 10:30:25 -0500
+
 asterisk (8:16.8.0-1~wazo3) wazo-dev-buster; urgency=medium
 
   * add User asterisk to the service file

--- a/debian/control
+++ b/debian/control
@@ -54,6 +54,7 @@ Build-Depends:
  quilt,
  unixodbc-dev,
  uuid-dev,
+ wazo-asterisk-doc-extractor,
  wget,
  xmlstarlet,
  zlib1g-dev

--- a/debian/rules
+++ b/debian/rules
@@ -85,6 +85,10 @@ binary-install/asterisk::
 	mkdir -p debian/$(cdbs_curpkg)/usr/share/asterisk
 	mv debian/tmp/var/lib/asterisk/documentation debian/$(cdbs_curpkg)/usr/share/asterisk/
 
+build/asterisk-doc::
+	mkdir -p $(BUILD_TREE)/doc/json
+	wazo-asterisk-doc-extractor $(BUILD_TREE)/doc/core-en_US.xml > $(BUILD_TREE)/doc/json/pjsip.json
+
 install/asterisk-doc::
 	dh_installexamples -p$(cdbs_curpkg) $(BUILD_TREE)/sample.call
 	dh_installexamples -p$(cdbs_curpkg) $(BUILD_TREE)/configs/*


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-asterisk-doc-extractor/pull/2
Depends-On: https://github.com/wazo-platform/xivo-build-tools/pull/16