### PR TITLE
postinst: chown rest-api spec files

### DIFF
--- a/debian/asterisk.postinst
+++ b/debian/asterisk.postinst
@@ -50,6 +50,10 @@ case "$1" in
 		fi
 	done
 
+	if [ -e /usr/share/asterisk/rest-api ]; then
+		chown -R $USER: /usr/share/asterisk/rest-api
+	fi
+
 	# Create /usr/local directory; policy 9.1.2
 	if [ ! -e /usr/local/share/asterisk/sounds ]; then
 		if mkdir -p /usr/local/share/asterisk/sounds 2>/dev/null ; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:17.3.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Fix rest-api spec ownership
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Fri, 20 Mar 2020 12:42:01 -0400
+
 asterisk (8:17.3.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Rebuild for vanilla and debug


### PR DESCRIPTION
in wazo-res-stasis-amqp we have a drop-in file that modifies the API spec
because the module adds resources to the HTTP API.

since the ExecPreStart is now run as user "asterisk", it fails to apply the
change and asterisk cannot start.

related commit: 84dd6972a914ef8c7545155f9ecd7b2a82e6479b