### PR TITLE
WAZO-1749 Asterisk 17.4.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+asterisk (8:17.4.0-1~wazo2) wazo-dev-buster; urgency=medium
+
+  * Asterisk 17.4.0
+  * libsrtp 1.5.4
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 20 May 2020 13:12:39 -0400
+
 asterisk (8:17.3.0-1~wazo4) wazo-dev-buster; urgency=medium
 
   * remove unused code in postinst

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:17.4.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * add upstream patch to fix a memory leak
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 05 May 2020 09:36:48 -0400
+
 asterisk (8:17.4.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Asterisk 17.4.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,15 +1,21 @@
+asterisk (8:17.4.0-1~wazo4) wazo-dev-buster; urgency=medium
+
+  * add upstream patch to fix a memory leak
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 20 May 2020 07:43:19 -0400
+
 asterisk (8:17.4.0-1~wazo3) wazo-dev-buster; urgency=medium
 
   * add upstream patch to fix a memory leak
 
- -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 05 May 2020 09:36:48 -0400
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 20 May 2020 07:42:00 -0400
 
 asterisk (8:17.4.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Asterisk 17.4.0
   * libsrtp 1.5.4
 
- -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 20 May 2020 13:12:39 -0400
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 20 May 2020 07:41:00 -0400
 
 asterisk (8:17.3.0-1~wazo4) wazo-dev-buster; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-asterisk (8:17.4.0-1~wazo4) wazo-dev-buster; urgency=medium
+asterisk (8:17.4.0-1~wazo5) wazo-dev-buster; urgency=medium
 
   * add upstream patch to fix a memory leak
 

--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,7 @@ Build-Depends:
  libspeexdsp-dev,
  libsqlite-dev,
  libsqlite3-dev,
- libsrtp2-dev (>= 2.2.0),
+ libsrtp0-dev (>= 1.5.4),
  libss7-dev (>= 2.0),
  libssl-dev,
  libtonezone-dev (>= 1:2.0.0),

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-17.3.0/contrib/scripts/astgenkey
+Index: asterisk-17.4.0/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-17.3.0.orig/contrib/scripts/astgenkey
-+++ asterisk-17.3.0/contrib/scripts/astgenkey
+--- asterisk-17.4.0.orig/contrib/scripts/astgenkey
++++ asterisk-17.4.0/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,11 +3,11 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-17.3.0/Makefile
+Index: asterisk-17.4.0/Makefile
 ===================================================================
---- asterisk-17.3.0.orig/Makefile
-+++ asterisk-17.3.0/Makefile
-@@ -430,7 +430,6 @@ dist-clean: distclean
+--- asterisk-17.4.0.orig/Makefile
++++ asterisk-17.4.0/Makefile
+@@ -434,7 +434,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	@$(MAKE) -C menuselect dist-clean
@@ -15,7 +15,7 @@ Index: asterisk-17.3.0/Makefile
  	rm -f menuselect.makeopts makeopts menuselect-tree menuselect.makedeps
  	rm -f config.log config.status config.cache
  	rm -rf autom4te.cache
-@@ -440,6 +439,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
+@@ -444,6 +443,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	rm -f doc/asterisk-ng-doxygen
  	rm -f build_tools/menuselect-deps
  

--- a/debian/patches/e2c5d29.diff
+++ b/debian/patches/e2c5d29.diff
@@ -1,0 +1,12 @@
+Index: asterisk-17.4.0/res/res_rtp_asterisk.c
+===================================================================
+--- asterisk-17.4.0.orig/res/res_rtp_asterisk.c
++++ asterisk-17.4.0/res/res_rtp_asterisk.c
+@@ -3578,6 +3578,7 @@ static void rtp_add_candidates_to_ice(st
+ 					pj_sockaddr_get_len(&pjtmp));
+ 			++count;
+ 		}
++		freeifaddrs(ifa);
+ 	}
+ 
+ 	/* If configured to use a STUN server to get our external mapped address do so */

--- a/debian/patches/fbb9359.diff
+++ b/debian/patches/fbb9359.diff
@@ -1,0 +1,59 @@
+From fbb9359cd311eadb847ff8dc9d0dcbbe34ecddc5 Mon Sep 17 00:00:00 2001
+From: George Joseph <gjoseph@digium.com>
+Date: Mon, 04 May 2020 10:31:57 -0600
+Subject: [PATCH] streams: Fix one memory leak and one formats ref issue
+
+ast_stream_topology_create_from_format_cap() was setting the
+stream->formats directly but not freeing the default formats.  This
+causes a memory leak.
+
+* ast_stream_topology_create_from_format_cap() now calls
+  ast_stream_set_formats() which properly cleans up the existing
+  stream formats.
+
+When cloning a stream, the source stream's format caps _pointer_ is
+copied to the new stream and it's reference count bumped.  If
+either stream is set to "removed", this will cause _both_ streams
+to have their format caps cleared.
+
+* ast_stream_clone() now creates a new format caps object and copies
+  the formats from the source stream instead of just copying the
+  pointer.
+
+ASTERISK-28870
+
+Change-Id: If697d81c3658eb7baeea6dab413b13423938fb53
+---
+
+Index: asterisk-17.4.0/main/stream.c
+===================================================================
+--- asterisk-17.4.0.orig/main/stream.c
++++ asterisk-17.4.0/main/stream.c
+@@ -137,9 +137,13 @@ struct ast_stream *ast_stream_clone(cons
+ 	memcpy(new_stream, stream, sizeof(*new_stream));
+ 	strcpy(new_stream->name, stream_name); /* Safe */
+ 	new_stream->group = -1;
+-	if (new_stream->formats) {
+-		ao2_ref(new_stream->formats, +1);
++
++	new_stream->formats = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
++	if (!new_stream->formats) {
++		ast_free(new_stream);
++		return NULL;
+ 	}
++	ast_format_cap_append_from_cap(new_stream->formats, stream->formats, AST_MEDIA_TYPE_UNKNOWN);
+ 
+ 	new_stream->metadata = ast_stream_get_metadata_list(stream);
+ 
+@@ -585,8 +589,9 @@ struct ast_stream_topology *ast_stream_t
+ 			ast_stream_topology_free(topology);
+ 			return NULL;
+ 		}
+-		/* We're transferring the initial ref so no bump needed */
+-		stream->formats = new_cap;
++
++		ast_stream_set_formats(stream, new_cap);
++		ao2_ref(new_cap, -1);
+ 		stream->state = AST_STREAM_STATE_SENDRECV;
+ 		if (ast_stream_topology_append_stream(topology, stream) == -1) {
+ 			ast_stream_free(stream);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,6 @@
 ### upstream fixes
+fbb9359.diff
+e2c5d29.diff
 deb_astgenkey-security
 deb_make-clean-fixes
 ## Wazo patches
@@ -21,4 +23,3 @@ xivo_ari_set_channel_var_bypass
 wazo_ari_expose_voicemail_functions
 wazo_sip_mobility
 wazo_bridge_variables
-fbb9359.diff

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ xivo_ari_set_channel_var_bypass
 wazo_ari_expose_voicemail_functions
 wazo_sip_mobility
 wazo_bridge_variables
+fbb9359.diff

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-17.3.0/res/ari.make
+Index: asterisk-17.4.0/res/ari.make
 ===================================================================
---- asterisk-17.3.0.orig/res/ari.make
-+++ asterisk-17.3.0/res/ari.make
+--- asterisk-17.4.0.orig/res/ari.make
++++ asterisk-17.4.0/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-17.3.0/res/ari/resource_wazo.c
+Index: asterisk-17.4.0/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-17.3.0/res/ari/resource_wazo.c
++++ asterisk-17.4.0/res/ari/resource_wazo.c
 @@ -0,0 +1,409 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -421,10 +421,10 @@ Index: asterisk-17.3.0/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-17.3.0/res/ari/resource_wazo.h
+Index: asterisk-17.4.0/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-17.3.0/res/ari/resource_wazo.h
++++ asterisk-17.4.0/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -626,10 +626,10 @@ Index: asterisk-17.3.0/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-17.3.0/res/res_ari_wazo.c
+Index: asterisk-17.4.0/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-17.3.0/res/res_ari_wazo.c
++++ asterisk-17.4.0/res/res_ari_wazo.c
 @@ -0,0 +1,596 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1227,10 +1227,10 @@ Index: asterisk-17.3.0/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-17.3.0/rest-api/api-docs/wazo.json
+Index: asterisk-17.4.0/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-17.3.0/rest-api/api-docs/wazo.json
++++ asterisk-17.4.0/rest-api/api-docs/wazo.json
 @@ -0,0 +1,300 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1532,10 +1532,10 @@ Index: asterisk-17.3.0/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-17.3.0/rest-api/resources.json
+Index: asterisk-17.4.0/rest-api/resources.json
 ===================================================================
---- asterisk-17.3.0.orig/rest-api/resources.json
-+++ asterisk-17.3.0/rest-api/resources.json
+--- asterisk-17.4.0.orig/rest-api/resources.json
++++ asterisk-17.4.0/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1547,10 +1547,10 @@ Index: asterisk-17.3.0/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-17.3.0/include/asterisk/app.h
+Index: asterisk-17.4.0/include/asterisk/app.h
 ===================================================================
---- asterisk-17.3.0.orig/include/asterisk/app.h
-+++ asterisk-17.3.0/include/asterisk/app.h
+--- asterisk-17.4.0.orig/include/asterisk/app.h
++++ asterisk-17.4.0/include/asterisk/app.h
 @@ -533,6 +533,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1640,10 +1640,10 @@ Index: asterisk-17.3.0/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-17.3.0/main/app.c
+Index: asterisk-17.4.0/main/app.c
 ===================================================================
---- asterisk-17.3.0.orig/main/app.c
-+++ asterisk-17.3.0/main/app.c
+--- asterisk-17.4.0.orig/main/app.c
++++ asterisk-17.4.0/main/app.c
 @@ -806,6 +806,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1703,10 +1703,10 @@ Index: asterisk-17.3.0/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-17.3.0/apps/app_voicemail.c
+Index: asterisk-17.4.0/apps/app_voicemail.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_voicemail.c
-+++ asterisk-17.3.0/apps/app_voicemail.c
+--- asterisk-17.4.0.orig/apps/app_voicemail.c
++++ asterisk-17.4.0/apps/app_voicemail.c
 @@ -580,6 +580,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
@@ -1944,10 +1944,10 @@ Index: asterisk-17.3.0/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-17.3.0/main/http.c
+Index: asterisk-17.4.0/main/http.c
 ===================================================================
---- asterisk-17.3.0.orig/main/http.c
-+++ asterisk-17.3.0/main/http.c
+--- asterisk-17.4.0.orig/main/http.c
++++ asterisk-17.4.0/main/http.c
 @@ -82,7 +82,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */

--- a/debian/patches/wazo_bridge_variables
+++ b/debian/patches/wazo_bridge_variables
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/include/asterisk/bridge.h
+Index: asterisk-17.4.0/include/asterisk/bridge.h
 ===================================================================
---- asterisk-17.3.0.orig/include/asterisk/bridge.h
-+++ asterisk-17.3.0/include/asterisk/bridge.h
+--- asterisk-17.4.0.orig/include/asterisk/bridge.h
++++ asterisk-17.4.0/include/asterisk/bridge.h
 @@ -253,6 +253,31 @@ typedef void (*ast_bridge_notify_masquer
  typedef int (*ast_bridge_merge_priority_fn)(struct ast_bridge *self);
  
@@ -85,10 +85,10 @@ Index: asterisk-17.3.0/include/asterisk/bridge.h
  #if defined(__cplusplus) || defined(c_plusplus)
  }
  #endif
-Index: asterisk-17.3.0/main/bridge.c
+Index: asterisk-17.4.0/main/bridge.c
 ===================================================================
---- asterisk-17.3.0.orig/main/bridge.c
-+++ asterisk-17.3.0/main/bridge.c
+--- asterisk-17.4.0.orig/main/bridge.c
++++ asterisk-17.4.0/main/bridge.c
 @@ -118,6 +118,8 @@
  #include "asterisk/core_local.h"
  #include "asterisk/core_unreal.h"
@@ -136,7 +136,7 @@ Index: asterisk-17.3.0/main/bridge.c
  };
  
  struct ast_bridge *ast_bridge_base_new(uint32_t capabilities, unsigned int flags, const char *creator, const char *name, const char *id)
-@@ -5483,6 +5509,14 @@ static int manager_bridge_tech_unsuspend
+@@ -5484,6 +5510,14 @@ static int manager_bridge_tech_unsuspend
  	return handle_manager_bridge_tech_suspend(s, m, 0);
  }
  
@@ -151,10 +151,10 @@ Index: asterisk-17.3.0/main/bridge.c
  static int manager_bridge_tech_list(struct mansession *s, const struct message *m)
  {
  	const char *id = astman_get_header(m, "ActionID");
-Index: asterisk-17.3.0/res/ari/resource_bridges.c
+Index: asterisk-17.4.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-17.3.0.orig/res/ari/resource_bridges.c
-+++ asterisk-17.3.0/res/ari/resource_bridges.c
+--- asterisk-17.4.0.orig/res/ari/resource_bridges.c
++++ asterisk-17.4.0/res/ari/resource_bridges.c
 @@ -44,6 +44,10 @@
  #include "asterisk/file.h"
  #include "asterisk/musiconhold.h"
@@ -288,10 +288,10 @@ Index: asterisk-17.3.0/res/ari/resource_bridges.c
 +	ast_ari_response_ok(response, response->message);
 +}
 \ No newline at end of file
-Index: asterisk-17.3.0/res/ari/resource_bridges.h
+Index: asterisk-17.4.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-17.3.0.orig/res/ari/resource_bridges.h
-+++ asterisk-17.3.0/res/ari/resource_bridges.h
+--- asterisk-17.4.0.orig/res/ari/resource_bridges.h
++++ asterisk-17.4.0/res/ari/resource_bridges.h
 @@ -393,5 +393,59 @@ int ast_ari_bridges_record_parse_body(
   * \param[out] response HTTP response
   */
@@ -352,10 +352,10 @@ Index: asterisk-17.3.0/res/ari/resource_bridges.h
 +void ast_ari_bridges_set_bridge_var(struct ast_variable *headers, struct ast_ari_bridges_set_bridge_var_args *args, struct ast_ari_response *response);
  
  #endif /* _ASTERISK_RESOURCE_BRIDGES_H */
-Index: asterisk-17.3.0/res/res_ari_bridges.c
+Index: asterisk-17.4.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-17.3.0.orig/res/res_ari_bridges.c
-+++ asterisk-17.3.0/res/res_ari_bridges.c
+--- asterisk-17.4.0.orig/res/res_ari_bridges.c
++++ asterisk-17.4.0/res/res_ari_bridges.c
 @@ -1454,6 +1454,179 @@ static void ast_ari_bridges_record_cb(
  fin: __attribute__((unused))
  	return;
@@ -564,10 +564,10 @@ Index: asterisk-17.3.0/res/res_ari_bridges.c
  };
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges = {
-Index: asterisk-17.3.0/rest-api/api-docs/bridges.json
+Index: asterisk-17.4.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-17.3.0.orig/rest-api/api-docs/bridges.json
-+++ asterisk-17.3.0/rest-api/api-docs/bridges.json
+--- asterisk-17.4.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-17.4.0/rest-api/api-docs/bridges.json
 @@ -565,7 +565,6 @@
  							"reason": "Bridge not in a Stasis application"
  						}
@@ -685,10 +685,10 @@ Index: asterisk-17.3.0/rest-api/api-docs/bridges.json
  				}
  			}
  		}
-Index: asterisk-17.3.0/include/asterisk/stasis_bridges.h
+Index: asterisk-17.4.0/include/asterisk/stasis_bridges.h
 ===================================================================
---- asterisk-17.3.0.orig/include/asterisk/stasis_bridges.h
-+++ asterisk-17.3.0/include/asterisk/stasis_bridges.h
+--- asterisk-17.4.0.orig/include/asterisk/stasis_bridges.h
++++ asterisk-17.4.0/include/asterisk/stasis_bridges.h
 @@ -94,6 +94,9 @@ struct ast_bridge_merge_message {
  	struct ast_bridge_snapshot *to;		/*!< Bridge to which channels will be added during the merge */
  };
@@ -717,10 +717,10 @@ Index: asterisk-17.3.0/include/asterisk/stasis_bridges.h
   * \brief Blob of data associated with a bridge.
   *
   * The \c blob is actually a JSON object of structured data. It has a "type" field
-Index: asterisk-17.3.0/main/stasis_bridges.c
+Index: asterisk-17.4.0/main/stasis_bridges.c
 ===================================================================
---- asterisk-17.3.0.orig/main/stasis_bridges.c
-+++ asterisk-17.3.0/main/stasis_bridges.c
+--- asterisk-17.4.0.orig/main/stasis_bridges.c
++++ asterisk-17.4.0/main/stasis_bridges.c
 @@ -37,6 +37,7 @@
  #include "asterisk/stasis_channels.h"
  #include "asterisk/bridge.h"
@@ -861,10 +861,10 @@ Index: asterisk-17.3.0/main/stasis_bridges.c
  
  	return res;
  }
-Index: asterisk-17.3.0/rest-api/api-docs/events.json
+Index: asterisk-17.4.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-17.3.0.orig/rest-api/api-docs/events.json
-+++ asterisk-17.3.0/rest-api/api-docs/events.json
+--- asterisk-17.4.0.orig/rest-api/api-docs/events.json
++++ asterisk-17.4.0/rest-api/api-docs/events.json
 @@ -162,6 +162,7 @@
  				"ApplicationMoveFailed",
  				"ApplicationReplaced",

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/res/res_pjsip/location.c
+Index: asterisk-17.4.0/res/res_pjsip/location.c
 ===================================================================
---- asterisk-17.3.0.orig/res/res_pjsip/location.c
-+++ asterisk-17.3.0/res/res_pjsip/location.c
+--- asterisk-17.4.0.orig/res/res_pjsip/location.c
++++ asterisk-17.4.0/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,10 +41,10 @@ Index: asterisk-17.3.0/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-17.3.0/res/res_pjsip_registrar.c
+Index: asterisk-17.4.0/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-17.3.0.orig/res/res_pjsip_registrar.c
-+++ asterisk-17.3.0/res/res_pjsip_registrar.c
+--- asterisk-17.4.0.orig/res/res_pjsip_registrar.c
++++ asterisk-17.4.0/res/res_pjsip_registrar.c
 @@ -753,6 +753,9 @@ static void register_aor_core(pjsip_rx_d
  
  		if (!contact) {
@@ -76,10 +76,10 @@ Index: asterisk-17.3.0/res/res_pjsip_registrar.c
  			if (!contact) {
  				ast_log(LOG_ERROR, "Unable to bind contact '%s' to AOR '%s'\n",
  					contact_uri, aor_name);
-Index: asterisk-17.3.0/include/asterisk/res_pjsip.h
+Index: asterisk-17.4.0/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-17.3.0.orig/include/asterisk/res_pjsip.h
-+++ asterisk-17.3.0/include/asterisk/res_pjsip.h
+--- asterisk-17.4.0.orig/include/asterisk/res_pjsip.h
++++ asterisk-17.4.0/include/asterisk/res_pjsip.h
 @@ -284,6 +284,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
@@ -98,11 +98,11 @@ Index: asterisk-17.3.0/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-17.3.0/res/res_pjsip.c
+Index: asterisk-17.4.0/res/res_pjsip.c
 ===================================================================
---- asterisk-17.3.0.orig/res/res_pjsip.c
-+++ asterisk-17.3.0/res/res_pjsip.c
-@@ -1505,6 +1505,12 @@
+--- asterisk-17.4.0.orig/res/res_pjsip.c
++++ asterisk-17.4.0/res/res_pjsip.c
+@@ -1521,6 +1521,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>
  				</configOption>

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/apps/app_queue.c
+Index: asterisk-17.4.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_queue.c
-+++ asterisk-17.3.0/apps/app_queue.c
+--- asterisk-17.4.0.orig/apps/app_queue.c
++++ asterisk-17.4.0/apps/app_queue.c
 @@ -2235,6 +2235,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/apps/app_queue.c
+Index: asterisk-17.4.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_queue.c
-+++ asterisk-17.3.0/apps/app_queue.c
+--- asterisk-17.4.0.orig/apps/app_queue.c
++++ asterisk-17.4.0/apps/app_queue.c
 @@ -6068,7 +6068,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/main/stasis_channels.c
+Index: asterisk-17.4.0/main/stasis_channels.c
 ===================================================================
---- asterisk-17.3.0.orig/main/stasis_channels.c
-+++ asterisk-17.3.0/main/stasis_channels.c
+--- asterisk-17.4.0.orig/main/stasis_channels.c
++++ asterisk-17.4.0/main/stasis_channels.c
 @@ -1573,6 +1573,47 @@ static struct ast_json *unhold_to_json(s
  		"channel", json_channel);
  }
@@ -65,10 +65,10 @@ Index: asterisk-17.3.0/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_agent_login_type,
-Index: asterisk-17.3.0/rest-api/api-docs/events.json
+Index: asterisk-17.4.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-17.3.0.orig/rest-api/api-docs/events.json
-+++ asterisk-17.3.0/rest-api/api-docs/events.json
+--- asterisk-17.4.0.orig/rest-api/api-docs/events.json
++++ asterisk-17.4.0/rest-api/api-docs/events.json
 @@ -189,7 +189,9 @@
  				"StasisStart",
  				"TextMessageReceived",

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/res/ari/resource_channels.c
+Index: asterisk-17.4.0/res/ari/resource_channels.c
 ===================================================================
---- asterisk-17.3.0.orig/res/ari/resource_channels.c
-+++ asterisk-17.3.0/res/ari/resource_channels.c
+--- asterisk-17.4.0.orig/res/ari/resource_channels.c
++++ asterisk-17.4.0/res/ari/resource_channels.c
 @@ -1553,6 +1553,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-17.3.0/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-17.3.0/res/ari/resource_channels.h
+Index: asterisk-17.4.0/res/ari/resource_channels.h
 ===================================================================
---- asterisk-17.3.0.orig/res/ari/resource_channels.h
-+++ asterisk-17.3.0/res/ari/resource_channels.h
+--- asterisk-17.4.0.orig/res/ari/resource_channels.h
++++ asterisk-17.4.0/res/ari/resource_channels.h
 @@ -691,6 +691,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *variable;
  	/*! The value to set the variable to */
@@ -37,10 +37,10 @@ Index: asterisk-17.3.0/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-17.3.0/res/res_ari_channels.c
+Index: asterisk-17.4.0/res/res_ari_channels.c
 ===================================================================
---- asterisk-17.3.0.orig/res/res_ari_channels.c
-+++ asterisk-17.3.0/res/res_ari_channels.c
+--- asterisk-17.4.0.orig/res/res_ari_channels.c
++++ asterisk-17.4.0/res/res_ari_channels.c
 @@ -2375,6 +2375,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->value = ast_json_string_get(field);
@@ -62,10 +62,10 @@ Index: asterisk-17.3.0/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-17.3.0/rest-api/api-docs/channels.json
+Index: asterisk-17.4.0/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-17.3.0.orig/rest-api/api-docs/channels.json
-+++ asterisk-17.3.0/rest-api/api-docs/channels.json
+--- asterisk-17.4.0.orig/rest-api/api-docs/channels.json
++++ asterisk-17.4.0/rest-api/api-docs/channels.json
 @@ -1470,6 +1470,15 @@
  							"required": false,
  							"allowMultiple": false,

--- a/debian/patches/xivo_banner
+++ b/debian/patches/xivo_banner
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/main/asterisk.c
+Index: asterisk-17.4.0/main/asterisk.c
 ===================================================================
---- asterisk-17.3.0.orig/main/asterisk.c
-+++ asterisk-17.3.0/main/asterisk.c
+--- asterisk-17.4.0.orig/main/asterisk.c
++++ asterisk-17.4.0/main/asterisk.c
 @@ -306,6 +306,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/main/ccss.c
+Index: asterisk-17.4.0/main/ccss.c
 ===================================================================
---- asterisk-17.3.0.orig/main/ccss.c
-+++ asterisk-17.3.0/main/ccss.c
+--- asterisk-17.4.0.orig/main/ccss.c
++++ asterisk-17.4.0/main/ccss.c
 @@ -2669,6 +2669,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/include/asterisk/channel.h
+Index: asterisk-17.4.0/include/asterisk/channel.h
 ===================================================================
---- asterisk-17.3.0.orig/include/asterisk/channel.h
-+++ asterisk-17.3.0/include/asterisk/channel.h
+--- asterisk-17.4.0.orig/include/asterisk/channel.h
++++ asterisk-17.4.0/include/asterisk/channel.h
 @@ -4514,6 +4514,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
@@ -21,11 +21,11 @@ Index: asterisk-17.3.0/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-17.3.0/main/channel.c
+Index: asterisk-17.4.0/main/channel.c
 ===================================================================
---- asterisk-17.3.0.orig/main/channel.c
-+++ asterisk-17.3.0/main/channel.c
-@@ -11060,3 +11060,8 @@ void ast_channel_clear_flag(struct ast_c
+--- asterisk-17.4.0.orig/main/channel.c
++++ asterisk-17.4.0/main/channel.c
+@@ -11053,3 +11053,8 @@ void ast_channel_clear_flag(struct ast_c
  	ast_clear_flag(ast_channel_flags(chan), flag);
  	ast_channel_unlock(chan);
  }

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/main/features.c
+Index: asterisk-17.4.0/main/features.c
 ===================================================================
---- asterisk-17.3.0.orig/main/features.c
-+++ asterisk-17.3.0/main/features.c
+--- asterisk-17.4.0.orig/main/features.c
++++ asterisk-17.4.0/main/features.c
 @@ -658,6 +658,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/include/asterisk/file.h
+Index: asterisk-17.4.0/include/asterisk/file.h
 ===================================================================
---- asterisk-17.3.0.orig/include/asterisk/file.h
-+++ asterisk-17.3.0/include/asterisk/file.h
+--- asterisk-17.4.0.orig/include/asterisk/file.h
++++ asterisk-17.4.0/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,10 +10,10 @@ Index: asterisk-17.3.0/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-17.3.0/main/bridge_basic.c
+Index: asterisk-17.4.0/main/bridge_basic.c
 ===================================================================
---- asterisk-17.3.0.orig/main/bridge_basic.c
-+++ asterisk-17.3.0/main/bridge_basic.c
+--- asterisk-17.4.0.orig/main/bridge_basic.c
++++ asterisk-17.4.0/main/bridge_basic.c
 @@ -3183,7 +3183,7 @@ static int grab_transfer(struct ast_chan
  	ast_channel_unlock(chan);
  

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,8 +1,8 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-17.3.0/apps/app_queue.c
+Index: asterisk-17.4.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_queue.c
-+++ asterisk-17.3.0/apps/app_queue.c
+--- asterisk-17.4.0.orig/apps/app_queue.c
++++ asterisk-17.4.0/apps/app_queue.c
 @@ -9964,6 +9964,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/apps/app_queue.c
+Index: asterisk-17.4.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_queue.c
-+++ asterisk-17.3.0/apps/app_queue.c
+--- asterisk-17.4.0.orig/apps/app_queue.c
++++ asterisk-17.4.0/apps/app_queue.c
 @@ -1578,6 +1578,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/apps/app_queue.c
+Index: asterisk-17.4.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_queue.c
-+++ asterisk-17.3.0/apps/app_queue.c
+--- asterisk-17.4.0.orig/apps/app_queue.c
++++ asterisk-17.4.0/apps/app_queue.c
 @@ -4281,7 +4281,7 @@ static int say_position(struct queue_ent
  		}
  

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/apps/app_queue.c
+Index: asterisk-17.4.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_queue.c
-+++ asterisk-17.3.0/apps/app_queue.c
+--- asterisk-17.4.0.orig/apps/app_queue.c
++++ asterisk-17.4.0/apps/app_queue.c
 @@ -6424,10 +6424,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/main/channel.c
+Index: asterisk-17.4.0/main/channel.c
 ===================================================================
---- asterisk-17.3.0.orig/main/channel.c
-+++ asterisk-17.3.0/main/channel.c
+--- asterisk-17.4.0.orig/main/channel.c
++++ asterisk-17.4.0/main/channel.c
 @@ -4849,7 +4849,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_sip_tel_uri
+++ b/debian/patches/xivo_sip_tel_uri
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/channels/sip/reqresp_parser.c
+Index: asterisk-17.4.0/channels/sip/reqresp_parser.c
 ===================================================================
---- asterisk-17.3.0.orig/channels/sip/reqresp_parser.c
-+++ asterisk-17.3.0/channels/sip/reqresp_parser.c
+--- asterisk-17.4.0.orig/channels/sip/reqresp_parser.c
++++ asterisk-17.4.0/channels/sip/reqresp_parser.c
 @@ -925,7 +925,7 @@ int get_name_and_number(const char *hdr,
  	tmp_number = get_in_brackets(header);
  

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,7 +1,7 @@
-Index: asterisk-17.3.0/apps/app_queue.c
+Index: asterisk-17.4.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.3.0.orig/apps/app_queue.c
-+++ asterisk-17.3.0/apps/app_queue.c
+--- asterisk-17.4.0.orig/apps/app_queue.c
++++ asterisk-17.4.0/apps/app_queue.c
 @@ -1403,6 +1403,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
@@ -2219,10 +2219,10 @@ Index: asterisk-17.3.0/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-17.3.0/configs/samples/queueskillrules.conf.sample
+Index: asterisk-17.4.0/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-17.3.0/configs/samples/queueskillrules.conf.sample
++++ asterisk-17.4.0/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2287,10 +2287,10 @@ Index: asterisk-17.3.0/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-17.3.0/configs/samples/queueskills.conf.sample
+Index: asterisk-17.4.0/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-17.3.0/configs/samples/queueskills.conf.sample
++++ asterisk-17.4.0/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
Also use libsrtp0 1.5.4 instead of libsrtp 2

https://wiki.asterisk.org/wiki/display/AST/libsrtp

The branch `asterisk-rc` as the same changes but is in version `~wazo3`
~~Load tests started at 2020-04-30 18:08 UTC~~
Load tests started at 2020-05-05 14:12 UTC

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1749