### PR TITLE
Upgrade to Asterisk 17.7.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:17.7.0-1~wazo2) wazo-dev-buster; urgency=medium
+
+  * Asterisk 17.7.0
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 30 Sep 2020 13:54:57 -0400
+
 asterisk (8:17.6.0-1~wazo3) wazo-dev-buster; urgency=medium
 
   * Fix logrotate command 

--- a/debian/patches/colp-patch.diff
+++ b/debian/patches/colp-patch.diff
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/include/asterisk/bridge_features.h
+Index: asterisk-17.7.0/include/asterisk/bridge_features.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/bridge_features.h
-+++ asterisk-17.6.0/include/asterisk/bridge_features.h
+--- asterisk-17.7.0.orig/include/asterisk/bridge_features.h
++++ asterisk-17.7.0/include/asterisk/bridge_features.h
 @@ -277,6 +277,8 @@ struct ast_bridge_features {
  	unsigned int mute:1;
  	/*! TRUE if DTMF should be passed into the bridge tech.  */
@@ -11,10 +11,10 @@ Index: asterisk-17.6.0/include/asterisk/bridge_features.h
  	/*! TRUE if text messaging is permitted. */
  	unsigned int text_messaging:1;
  };
-Index: asterisk-17.6.0/include/asterisk/stasis_app.h
+Index: asterisk-17.7.0/include/asterisk/stasis_app.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/stasis_app.h
-+++ asterisk-17.6.0/include/asterisk/stasis_app.h
+--- asterisk-17.7.0.orig/include/asterisk/stasis_app.h
++++ asterisk-17.7.0/include/asterisk/stasis_app.h
 @@ -838,6 +838,16 @@ void stasis_app_control_mute_in_bridge(
  	struct stasis_app_control *control, int mute);
  
@@ -32,10 +32,10 @@ Index: asterisk-17.6.0/include/asterisk/stasis_app.h
   * \since 12
   * \brief Gets the bridge currently associated with a control object.
   *
-Index: asterisk-17.6.0/res/ari/resource_bridges.c
+Index: asterisk-17.7.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-17.6.0.orig/res/ari/resource_bridges.c
-+++ asterisk-17.6.0/res/ari/resource_bridges.c
+--- asterisk-17.7.0.orig/res/ari/resource_bridges.c
++++ asterisk-17.7.0/res/ari/resource_bridges.c
 @@ -221,6 +221,7 @@ void ast_ari_bridges_add_channel(struct
  		if (!stasis_app_control_bridge_features_init(list->controls[i])) {
  			stasis_app_control_absorb_dtmf_in_bridge(list->controls[i], args->absorb_dtmf);
@@ -44,10 +44,10 @@ Index: asterisk-17.6.0/res/ari/resource_bridges.c
  		}
  	}
  
-Index: asterisk-17.6.0/res/ari/resource_bridges.h
+Index: asterisk-17.7.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-17.6.0.orig/res/ari/resource_bridges.h
-+++ asterisk-17.6.0/res/ari/resource_bridges.h
+--- asterisk-17.7.0.orig/res/ari/resource_bridges.h
++++ asterisk-17.7.0/res/ari/resource_bridges.h
 @@ -154,6 +154,8 @@ struct ast_ari_bridges_add_channel_args
  	int absorb_dtmf;
  	/*! Mute audio from this channel, preventing it to pass through to the bridge */
@@ -57,10 +57,10 @@ Index: asterisk-17.6.0/res/ari/resource_bridges.h
  };
  /*!
   * \brief Body parsing function for /bridges/{bridgeId}/addChannel.
-Index: asterisk-17.6.0/res/res_ari_bridges.c
+Index: asterisk-17.7.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-17.6.0.orig/res/res_ari_bridges.c
-+++ asterisk-17.6.0/res/res_ari_bridges.c
+--- asterisk-17.7.0.orig/res/res_ari_bridges.c
++++ asterisk-17.7.0/res/res_ari_bridges.c
 @@ -440,6 +440,10 @@ int ast_ari_bridges_add_channel_parse_bo
  	if (field) {
  		args->mute = ast_json_is_true(field);
@@ -82,10 +82,10 @@ Index: asterisk-17.6.0/res/res_ari_bridges.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-17.6.0/res/stasis/control.c
+Index: asterisk-17.7.0/res/stasis/control.c
 ===================================================================
---- asterisk-17.6.0.orig/res/stasis/control.c
-+++ asterisk-17.6.0/res/stasis/control.c
+--- asterisk-17.7.0.orig/res/stasis/control.c
++++ asterisk-17.7.0/res/stasis/control.c
 @@ -1285,6 +1285,7 @@ int control_swap_channel_in_bridge(struc
  {
  	int res;
@@ -126,10 +126,10 @@ Index: asterisk-17.6.0/res/stasis/control.c
  void control_flush_queue(struct stasis_app_control *control)
  {
  	struct ao2_iterator iter;
-Index: asterisk-17.6.0/rest-api/api-docs/bridges.json
+Index: asterisk-17.7.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-17.6.0.orig/rest-api/api-docs/bridges.json
-+++ asterisk-17.6.0/rest-api/api-docs/bridges.json
+--- asterisk-17.7.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-17.7.0/rest-api/api-docs/bridges.json
 @@ -191,6 +191,15 @@
  							"allowMultiple": false,
  							"dataType": "boolean",

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-17.6.0/contrib/scripts/astgenkey
+Index: asterisk-17.7.0/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-17.6.0.orig/contrib/scripts/astgenkey
-+++ asterisk-17.6.0/contrib/scripts/astgenkey
+--- asterisk-17.7.0.orig/contrib/scripts/astgenkey
++++ asterisk-17.7.0/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,10 +3,10 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-17.6.0/Makefile
+Index: asterisk-17.7.0/Makefile
 ===================================================================
---- asterisk-17.6.0.orig/Makefile
-+++ asterisk-17.6.0/Makefile
+--- asterisk-17.7.0.orig/Makefile
++++ asterisk-17.7.0/Makefile
 @@ -434,7 +434,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-17.6.0/res/ari.make
+Index: asterisk-17.7.0/res/ari.make
 ===================================================================
---- asterisk-17.6.0.orig/res/ari.make
-+++ asterisk-17.6.0/res/ari.make
+--- asterisk-17.7.0.orig/res/ari.make
++++ asterisk-17.7.0/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-17.6.0/res/ari/resource_wazo.c
+Index: asterisk-17.7.0/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-17.6.0/res/ari/resource_wazo.c
++++ asterisk-17.7.0/res/ari/resource_wazo.c
 @@ -0,0 +1,409 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -421,10 +421,10 @@ Index: asterisk-17.6.0/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-17.6.0/res/ari/resource_wazo.h
+Index: asterisk-17.7.0/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-17.6.0/res/ari/resource_wazo.h
++++ asterisk-17.7.0/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -626,10 +626,10 @@ Index: asterisk-17.6.0/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-17.6.0/res/res_ari_wazo.c
+Index: asterisk-17.7.0/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-17.6.0/res/res_ari_wazo.c
++++ asterisk-17.7.0/res/res_ari_wazo.c
 @@ -0,0 +1,596 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1227,10 +1227,10 @@ Index: asterisk-17.6.0/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-17.6.0/rest-api/api-docs/wazo.json
+Index: asterisk-17.7.0/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-17.6.0/rest-api/api-docs/wazo.json
++++ asterisk-17.7.0/rest-api/api-docs/wazo.json
 @@ -0,0 +1,300 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1532,10 +1532,10 @@ Index: asterisk-17.6.0/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-17.6.0/rest-api/resources.json
+Index: asterisk-17.7.0/rest-api/resources.json
 ===================================================================
---- asterisk-17.6.0.orig/rest-api/resources.json
-+++ asterisk-17.6.0/rest-api/resources.json
+--- asterisk-17.7.0.orig/rest-api/resources.json
++++ asterisk-17.7.0/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1547,10 +1547,10 @@ Index: asterisk-17.6.0/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-17.6.0/include/asterisk/app.h
+Index: asterisk-17.7.0/include/asterisk/app.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/app.h
-+++ asterisk-17.6.0/include/asterisk/app.h
+--- asterisk-17.7.0.orig/include/asterisk/app.h
++++ asterisk-17.7.0/include/asterisk/app.h
 @@ -533,6 +533,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1640,10 +1640,10 @@ Index: asterisk-17.6.0/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-17.6.0/main/app.c
+Index: asterisk-17.7.0/main/app.c
 ===================================================================
---- asterisk-17.6.0.orig/main/app.c
-+++ asterisk-17.6.0/main/app.c
+--- asterisk-17.7.0.orig/main/app.c
++++ asterisk-17.7.0/main/app.c
 @@ -809,6 +809,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1703,10 +1703,10 @@ Index: asterisk-17.6.0/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-17.6.0/apps/app_voicemail.c
+Index: asterisk-17.7.0/apps/app_voicemail.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_voicemail.c
-+++ asterisk-17.6.0/apps/app_voicemail.c
+--- asterisk-17.7.0.orig/apps/app_voicemail.c
++++ asterisk-17.7.0/apps/app_voicemail.c
 @@ -580,6 +580,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
@@ -1944,10 +1944,10 @@ Index: asterisk-17.6.0/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-17.6.0/main/http.c
+Index: asterisk-17.7.0/main/http.c
 ===================================================================
---- asterisk-17.6.0.orig/main/http.c
-+++ asterisk-17.6.0/main/http.c
+--- asterisk-17.7.0.orig/main/http.c
++++ asterisk-17.7.0/main/http.c
 @@ -82,7 +82,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */

--- a/debian/patches/wazo_bridge_variables
+++ b/debian/patches/wazo_bridge_variables
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/include/asterisk/bridge.h
+Index: asterisk-17.7.0/include/asterisk/bridge.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/bridge.h
-+++ asterisk-17.6.0/include/asterisk/bridge.h
+--- asterisk-17.7.0.orig/include/asterisk/bridge.h
++++ asterisk-17.7.0/include/asterisk/bridge.h
 @@ -253,6 +253,31 @@ typedef void (*ast_bridge_notify_masquer
  typedef int (*ast_bridge_merge_priority_fn)(struct ast_bridge *self);
  
@@ -85,10 +85,10 @@ Index: asterisk-17.6.0/include/asterisk/bridge.h
  #if defined(__cplusplus) || defined(c_plusplus)
  }
  #endif
-Index: asterisk-17.6.0/main/bridge.c
+Index: asterisk-17.7.0/main/bridge.c
 ===================================================================
---- asterisk-17.6.0.orig/main/bridge.c
-+++ asterisk-17.6.0/main/bridge.c
+--- asterisk-17.7.0.orig/main/bridge.c
++++ asterisk-17.7.0/main/bridge.c
 @@ -118,6 +118,8 @@
  #include "asterisk/core_local.h"
  #include "asterisk/core_unreal.h"
@@ -136,7 +136,7 @@ Index: asterisk-17.6.0/main/bridge.c
  };
  
  struct ast_bridge *ast_bridge_base_new(uint32_t capabilities, unsigned int flags, const char *creator, const char *name, const char *id)
-@@ -5483,6 +5509,14 @@ static int manager_bridge_tech_unsuspend
+@@ -5484,6 +5510,14 @@ static int manager_bridge_tech_unsuspend
  	return handle_manager_bridge_tech_suspend(s, m, 0);
  }
  
@@ -151,10 +151,10 @@ Index: asterisk-17.6.0/main/bridge.c
  static int manager_bridge_tech_list(struct mansession *s, const struct message *m)
  {
  	const char *id = astman_get_header(m, "ActionID");
-Index: asterisk-17.6.0/res/ari/resource_bridges.c
+Index: asterisk-17.7.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-17.6.0.orig/res/ari/resource_bridges.c
-+++ asterisk-17.6.0/res/ari/resource_bridges.c
+--- asterisk-17.7.0.orig/res/ari/resource_bridges.c
++++ asterisk-17.7.0/res/ari/resource_bridges.c
 @@ -44,6 +44,10 @@
  #include "asterisk/file.h"
  #include "asterisk/musiconhold.h"
@@ -288,10 +288,10 @@ Index: asterisk-17.6.0/res/ari/resource_bridges.c
 +	ast_ari_response_ok(response, response->message);
 +}
 \ No newline at end of file
-Index: asterisk-17.6.0/res/ari/resource_bridges.h
+Index: asterisk-17.7.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-17.6.0.orig/res/ari/resource_bridges.h
-+++ asterisk-17.6.0/res/ari/resource_bridges.h
+--- asterisk-17.7.0.orig/res/ari/resource_bridges.h
++++ asterisk-17.7.0/res/ari/resource_bridges.h
 @@ -395,5 +395,59 @@ int ast_ari_bridges_record_parse_body(
   * \param[out] response HTTP response
   */
@@ -352,10 +352,10 @@ Index: asterisk-17.6.0/res/ari/resource_bridges.h
 +void ast_ari_bridges_set_bridge_var(struct ast_variable *headers, struct ast_ari_bridges_set_bridge_var_args *args, struct ast_ari_response *response);
  
  #endif /* _ASTERISK_RESOURCE_BRIDGES_H */
-Index: asterisk-17.6.0/res/res_ari_bridges.c
+Index: asterisk-17.7.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-17.6.0.orig/res/res_ari_bridges.c
-+++ asterisk-17.6.0/res/res_ari_bridges.c
+--- asterisk-17.7.0.orig/res/res_ari_bridges.c
++++ asterisk-17.7.0/res/res_ari_bridges.c
 @@ -1461,6 +1461,179 @@ static void ast_ari_bridges_record_cb(
  fin: __attribute__((unused))
  	return;
@@ -564,10 +564,10 @@ Index: asterisk-17.6.0/res/res_ari_bridges.c
  };
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges = {
-Index: asterisk-17.6.0/rest-api/api-docs/bridges.json
+Index: asterisk-17.7.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-17.6.0.orig/rest-api/api-docs/bridges.json
-+++ asterisk-17.6.0/rest-api/api-docs/bridges.json
+--- asterisk-17.7.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-17.7.0/rest-api/api-docs/bridges.json
 @@ -574,7 +574,6 @@
  							"reason": "Bridge not in a Stasis application"
  						}
@@ -685,10 +685,10 @@ Index: asterisk-17.6.0/rest-api/api-docs/bridges.json
  				}
  			}
  		}
-Index: asterisk-17.6.0/include/asterisk/stasis_bridges.h
+Index: asterisk-17.7.0/include/asterisk/stasis_bridges.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/stasis_bridges.h
-+++ asterisk-17.6.0/include/asterisk/stasis_bridges.h
+--- asterisk-17.7.0.orig/include/asterisk/stasis_bridges.h
++++ asterisk-17.7.0/include/asterisk/stasis_bridges.h
 @@ -94,6 +94,9 @@ struct ast_bridge_merge_message {
  	struct ast_bridge_snapshot *to;		/*!< Bridge to which channels will be added during the merge */
  };
@@ -717,10 +717,10 @@ Index: asterisk-17.6.0/include/asterisk/stasis_bridges.h
   * \brief Blob of data associated with a bridge.
   *
   * The \c blob is actually a JSON object of structured data. It has a "type" field
-Index: asterisk-17.6.0/main/stasis_bridges.c
+Index: asterisk-17.7.0/main/stasis_bridges.c
 ===================================================================
---- asterisk-17.6.0.orig/main/stasis_bridges.c
-+++ asterisk-17.6.0/main/stasis_bridges.c
+--- asterisk-17.7.0.orig/main/stasis_bridges.c
++++ asterisk-17.7.0/main/stasis_bridges.c
 @@ -37,6 +37,7 @@
  #include "asterisk/stasis_channels.h"
  #include "asterisk/bridge.h"
@@ -861,10 +861,10 @@ Index: asterisk-17.6.0/main/stasis_bridges.c
  
  	return res;
  }
-Index: asterisk-17.6.0/rest-api/api-docs/events.json
+Index: asterisk-17.7.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-17.6.0.orig/rest-api/api-docs/events.json
-+++ asterisk-17.6.0/rest-api/api-docs/events.json
+--- asterisk-17.7.0.orig/rest-api/api-docs/events.json
++++ asterisk-17.7.0/rest-api/api-docs/events.json
 @@ -162,6 +162,7 @@
  				"ApplicationMoveFailed",
  				"ApplicationReplaced",

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/res/res_pjsip/location.c
+Index: asterisk-17.7.0/res/res_pjsip/location.c
 ===================================================================
---- asterisk-17.6.0.orig/res/res_pjsip/location.c
-+++ asterisk-17.6.0/res/res_pjsip/location.c
+--- asterisk-17.7.0.orig/res/res_pjsip/location.c
++++ asterisk-17.7.0/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,11 +41,11 @@ Index: asterisk-17.6.0/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-17.6.0/res/res_pjsip_registrar.c
+Index: asterisk-17.7.0/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-17.6.0.orig/res/res_pjsip_registrar.c
-+++ asterisk-17.6.0/res/res_pjsip_registrar.c
-@@ -754,6 +754,9 @@ static void register_aor_core(pjsip_rx_d
+--- asterisk-17.7.0.orig/res/res_pjsip_registrar.c
++++ asterisk-17.7.0/res/res_pjsip_registrar.c
+@@ -758,6 +758,9 @@ static void register_aor_core(pjsip_rx_d
  
  		if (!contact) {
  			int prune_on_boot;
@@ -55,7 +55,7 @@ Index: asterisk-17.6.0/res/res_pjsip_registrar.c
  
  			/* If they are actually trying to delete a contact that does not exist... be forgiving */
  			if (!expiration) {
-@@ -762,12 +765,19 @@ static void register_aor_core(pjsip_rx_d
+@@ -766,12 +769,19 @@ static void register_aor_core(pjsip_rx_d
  				continue;
  			}
  
@@ -76,10 +76,10 @@ Index: asterisk-17.6.0/res/res_pjsip_registrar.c
  			if (!contact) {
  				ast_log(LOG_ERROR, "Unable to bind contact '%s' to AOR '%s'\n",
  					contact_uri, aor_name);
-Index: asterisk-17.6.0/include/asterisk/res_pjsip.h
+Index: asterisk-17.7.0/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/res_pjsip.h
-+++ asterisk-17.6.0/include/asterisk/res_pjsip.h
+--- asterisk-17.7.0.orig/include/asterisk/res_pjsip.h
++++ asterisk-17.7.0/include/asterisk/res_pjsip.h
 @@ -296,6 +296,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
@@ -98,10 +98,10 @@ Index: asterisk-17.6.0/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-17.6.0/res/res_pjsip.c
+Index: asterisk-17.7.0/res/res_pjsip.c
 ===================================================================
---- asterisk-17.6.0.orig/res/res_pjsip.c
-+++ asterisk-17.6.0/res/res_pjsip.c
+--- asterisk-17.7.0.orig/res/res_pjsip.c
++++ asterisk-17.7.0/res/res_pjsip.c
 @@ -1521,6 +1521,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/apps/app_queue.c
+Index: asterisk-17.7.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_queue.c
-+++ asterisk-17.6.0/apps/app_queue.c
+--- asterisk-17.7.0.orig/apps/app_queue.c
++++ asterisk-17.7.0/apps/app_queue.c
 @@ -2233,6 +2233,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/apps/app_queue.c
+Index: asterisk-17.7.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_queue.c
-+++ asterisk-17.6.0/apps/app_queue.c
+--- asterisk-17.7.0.orig/apps/app_queue.c
++++ asterisk-17.7.0/apps/app_queue.c
 @@ -6067,7 +6067,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/main/stasis_channels.c
+Index: asterisk-17.7.0/main/stasis_channels.c
 ===================================================================
---- asterisk-17.6.0.orig/main/stasis_channels.c
-+++ asterisk-17.6.0/main/stasis_channels.c
+--- asterisk-17.7.0.orig/main/stasis_channels.c
++++ asterisk-17.7.0/main/stasis_channels.c
 @@ -1573,6 +1573,47 @@ static struct ast_json *unhold_to_json(s
  		"channel", json_channel);
  }
@@ -65,10 +65,10 @@ Index: asterisk-17.6.0/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_agent_login_type,
-Index: asterisk-17.6.0/rest-api/api-docs/events.json
+Index: asterisk-17.7.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-17.6.0.orig/rest-api/api-docs/events.json
-+++ asterisk-17.6.0/rest-api/api-docs/events.json
+--- asterisk-17.7.0.orig/rest-api/api-docs/events.json
++++ asterisk-17.7.0/rest-api/api-docs/events.json
 @@ -189,7 +189,9 @@
  				"StasisStart",
  				"TextMessageReceived",

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/res/ari/resource_channels.c
+Index: asterisk-17.7.0/res/ari/resource_channels.c
 ===================================================================
---- asterisk-17.6.0.orig/res/ari/resource_channels.c
-+++ asterisk-17.6.0/res/ari/resource_channels.c
+--- asterisk-17.7.0.orig/res/ari/resource_channels.c
++++ asterisk-17.7.0/res/ari/resource_channels.c
 @@ -1553,6 +1553,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-17.6.0/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-17.6.0/res/ari/resource_channels.h
+Index: asterisk-17.7.0/res/ari/resource_channels.h
 ===================================================================
---- asterisk-17.6.0.orig/res/ari/resource_channels.h
-+++ asterisk-17.6.0/res/ari/resource_channels.h
+--- asterisk-17.7.0.orig/res/ari/resource_channels.h
++++ asterisk-17.7.0/res/ari/resource_channels.h
 @@ -693,6 +693,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *variable;
  	/*! The value to set the variable to */
@@ -37,10 +37,10 @@ Index: asterisk-17.6.0/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-17.6.0/res/res_ari_channels.c
+Index: asterisk-17.7.0/res/res_ari_channels.c
 ===================================================================
---- asterisk-17.6.0.orig/res/res_ari_channels.c
-+++ asterisk-17.6.0/res/res_ari_channels.c
+--- asterisk-17.7.0.orig/res/res_ari_channels.c
++++ asterisk-17.7.0/res/res_ari_channels.c
 @@ -2372,6 +2372,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->value = ast_json_string_get(field);
@@ -62,10 +62,10 @@ Index: asterisk-17.6.0/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-17.6.0/rest-api/api-docs/channels.json
+Index: asterisk-17.7.0/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-17.6.0.orig/rest-api/api-docs/channels.json
-+++ asterisk-17.6.0/rest-api/api-docs/channels.json
+--- asterisk-17.7.0.orig/rest-api/api-docs/channels.json
++++ asterisk-17.7.0/rest-api/api-docs/channels.json
 @@ -1478,6 +1478,15 @@
  							"required": false,
  							"allowMultiple": false,

--- a/debian/patches/xivo_banner
+++ b/debian/patches/xivo_banner
@@ -1,8 +1,8 @@
-Index: asterisk-17.6.0/main/asterisk.c
+Index: asterisk-17.7.0/main/asterisk.c
 ===================================================================
---- asterisk-17.6.0.orig/main/asterisk.c
-+++ asterisk-17.6.0/main/asterisk.c
-@@ -306,6 +306,10 @@ int daemon(int, int);  /* defined in lib
+--- asterisk-17.7.0.orig/main/asterisk.c
++++ asterisk-17.7.0/main/asterisk.c
+@@ -307,6 +307,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \
                  "certain conditions. Type 'core show license' for details.\n" \

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/main/ccss.c
+Index: asterisk-17.7.0/main/ccss.c
 ===================================================================
---- asterisk-17.6.0.orig/main/ccss.c
-+++ asterisk-17.6.0/main/ccss.c
+--- asterisk-17.7.0.orig/main/ccss.c
++++ asterisk-17.7.0/main/ccss.c
 @@ -2669,6 +2669,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/include/asterisk/channel.h
+Index: asterisk-17.7.0/include/asterisk/channel.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/channel.h
-+++ asterisk-17.6.0/include/asterisk/channel.h
+--- asterisk-17.7.0.orig/include/asterisk/channel.h
++++ asterisk-17.7.0/include/asterisk/channel.h
 @@ -4514,6 +4514,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
@@ -21,10 +21,10 @@ Index: asterisk-17.6.0/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-17.6.0/main/channel.c
+Index: asterisk-17.7.0/main/channel.c
 ===================================================================
---- asterisk-17.6.0.orig/main/channel.c
-+++ asterisk-17.6.0/main/channel.c
+--- asterisk-17.7.0.orig/main/channel.c
++++ asterisk-17.7.0/main/channel.c
 @@ -11063,3 +11063,8 @@ void ast_channel_clear_flag(struct ast_c
  	ast_clear_flag(ast_channel_flags(chan), flag);
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/main/features.c
+Index: asterisk-17.7.0/main/features.c
 ===================================================================
---- asterisk-17.6.0.orig/main/features.c
-+++ asterisk-17.6.0/main/features.c
+--- asterisk-17.7.0.orig/main/features.c
++++ asterisk-17.7.0/main/features.c
 @@ -658,6 +658,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/include/asterisk/file.h
+Index: asterisk-17.7.0/include/asterisk/file.h
 ===================================================================
---- asterisk-17.6.0.orig/include/asterisk/file.h
-+++ asterisk-17.6.0/include/asterisk/file.h
+--- asterisk-17.7.0.orig/include/asterisk/file.h
++++ asterisk-17.7.0/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,10 +10,10 @@ Index: asterisk-17.6.0/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-17.6.0/main/bridge_basic.c
+Index: asterisk-17.7.0/main/bridge_basic.c
 ===================================================================
---- asterisk-17.6.0.orig/main/bridge_basic.c
-+++ asterisk-17.6.0/main/bridge_basic.c
+--- asterisk-17.7.0.orig/main/bridge_basic.c
++++ asterisk-17.7.0/main/bridge_basic.c
 @@ -3183,7 +3183,7 @@ static int grab_transfer(struct ast_chan
  	ast_channel_unlock(chan);
  

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,8 +1,8 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-17.6.0/apps/app_queue.c
+Index: asterisk-17.7.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_queue.c
-+++ asterisk-17.6.0/apps/app_queue.c
+--- asterisk-17.7.0.orig/apps/app_queue.c
++++ asterisk-17.7.0/apps/app_queue.c
 @@ -9987,6 +9987,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/apps/app_queue.c
+Index: asterisk-17.7.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_queue.c
-+++ asterisk-17.6.0/apps/app_queue.c
+--- asterisk-17.7.0.orig/apps/app_queue.c
++++ asterisk-17.7.0/apps/app_queue.c
 @@ -1576,6 +1576,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/apps/app_queue.c
+Index: asterisk-17.7.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_queue.c
-+++ asterisk-17.6.0/apps/app_queue.c
+--- asterisk-17.7.0.orig/apps/app_queue.c
++++ asterisk-17.7.0/apps/app_queue.c
 @@ -4279,7 +4279,7 @@ static int say_position(struct queue_ent
  		}
  

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/apps/app_queue.c
+Index: asterisk-17.7.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_queue.c
-+++ asterisk-17.6.0/apps/app_queue.c
+--- asterisk-17.7.0.orig/apps/app_queue.c
++++ asterisk-17.7.0/apps/app_queue.c
 @@ -6423,10 +6423,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/main/channel.c
+Index: asterisk-17.7.0/main/channel.c
 ===================================================================
---- asterisk-17.6.0.orig/main/channel.c
-+++ asterisk-17.6.0/main/channel.c
+--- asterisk-17.7.0.orig/main/channel.c
++++ asterisk-17.7.0/main/channel.c
 @@ -4854,7 +4854,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_sip_tel_uri
+++ b/debian/patches/xivo_sip_tel_uri
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/channels/sip/reqresp_parser.c
+Index: asterisk-17.7.0/channels/sip/reqresp_parser.c
 ===================================================================
---- asterisk-17.6.0.orig/channels/sip/reqresp_parser.c
-+++ asterisk-17.6.0/channels/sip/reqresp_parser.c
+--- asterisk-17.7.0.orig/channels/sip/reqresp_parser.c
++++ asterisk-17.7.0/channels/sip/reqresp_parser.c
 @@ -925,7 +925,7 @@ int get_name_and_number(const char *hdr,
  	tmp_number = get_in_brackets(header);
  

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,7 +1,7 @@
-Index: asterisk-17.6.0/apps/app_queue.c
+Index: asterisk-17.7.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.6.0.orig/apps/app_queue.c
-+++ asterisk-17.6.0/apps/app_queue.c
+--- asterisk-17.7.0.orig/apps/app_queue.c
++++ asterisk-17.7.0/apps/app_queue.c
 @@ -1403,6 +1403,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
@@ -2219,10 +2219,10 @@ Index: asterisk-17.6.0/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-17.6.0/configs/samples/queueskillrules.conf.sample
+Index: asterisk-17.7.0/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-17.6.0/configs/samples/queueskillrules.conf.sample
++++ asterisk-17.7.0/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2287,10 +2287,10 @@ Index: asterisk-17.6.0/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-17.6.0/configs/samples/queueskills.conf.sample
+Index: asterisk-17.7.0/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-17.6.0/configs/samples/queueskills.conf.sample
++++ asterisk-17.7.0/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
no fuzz on patches

The version is suffixed `~wazo2` to allow smooth upgrades from asterisk-rc which is `~wazo1`

Load tests have been started on 2020-09-30 at 17:30 UTC