### PR TITLE
logrotate: fix asterisk logger reload

### DIFF
--- a/debian/asterisk.logrotate
+++ b/debian/asterisk.logrotate
@@ -9,6 +9,6 @@
         sharedscripts
         compress
         postrotate
-                /usr/sbin/invoke-rc.d asterisk logger-reload >/dev/null 2>/dev/null
+                /usr/sbin/asterisk -rx 'logger reload' >/dev/null 2>/dev/null
         endscript
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:17.6.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Fix logrotate command 
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 30 Sep 2020 13:54:56 -0400
+
 asterisk (8:17.6.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Add COLP patch


### PR DESCRIPTION
Why:

* logger-reload was only available in init.d file, not anymore with
systemd