### PR TITLE
Upgrade patches for Asterisk 17.8.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:17.8.0-1~wazo2) wazo-dev-buster; urgency=medium
+
+  * Asterisk 17.8.0
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 20 Oct 2020 09:00:05 -0400
+
 asterisk (8:17.7.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Asterisk 17.7.0

--- a/debian/patches/colp-patch.diff
+++ b/debian/patches/colp-patch.diff
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/include/asterisk/bridge_features.h
+Index: asterisk-17.8.0/include/asterisk/bridge_features.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/bridge_features.h
-+++ asterisk-17.7.0/include/asterisk/bridge_features.h
+--- asterisk-17.8.0.orig/include/asterisk/bridge_features.h
++++ asterisk-17.8.0/include/asterisk/bridge_features.h
 @@ -277,6 +277,8 @@ struct ast_bridge_features {
  	unsigned int mute:1;
  	/*! TRUE if DTMF should be passed into the bridge tech.  */
@@ -11,10 +11,10 @@ Index: asterisk-17.7.0/include/asterisk/bridge_features.h
  	/*! TRUE if text messaging is permitted. */
  	unsigned int text_messaging:1;
  };
-Index: asterisk-17.7.0/include/asterisk/stasis_app.h
+Index: asterisk-17.8.0/include/asterisk/stasis_app.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/stasis_app.h
-+++ asterisk-17.7.0/include/asterisk/stasis_app.h
+--- asterisk-17.8.0.orig/include/asterisk/stasis_app.h
++++ asterisk-17.8.0/include/asterisk/stasis_app.h
 @@ -838,6 +838,16 @@ void stasis_app_control_mute_in_bridge(
  	struct stasis_app_control *control, int mute);
  
@@ -32,10 +32,10 @@ Index: asterisk-17.7.0/include/asterisk/stasis_app.h
   * \since 12
   * \brief Gets the bridge currently associated with a control object.
   *
-Index: asterisk-17.7.0/res/ari/resource_bridges.c
+Index: asterisk-17.8.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-17.7.0.orig/res/ari/resource_bridges.c
-+++ asterisk-17.7.0/res/ari/resource_bridges.c
+--- asterisk-17.8.0.orig/res/ari/resource_bridges.c
++++ asterisk-17.8.0/res/ari/resource_bridges.c
 @@ -221,6 +221,7 @@ void ast_ari_bridges_add_channel(struct
  		if (!stasis_app_control_bridge_features_init(list->controls[i])) {
  			stasis_app_control_absorb_dtmf_in_bridge(list->controls[i], args->absorb_dtmf);
@@ -44,10 +44,10 @@ Index: asterisk-17.7.0/res/ari/resource_bridges.c
  		}
  	}
  
-Index: asterisk-17.7.0/res/ari/resource_bridges.h
+Index: asterisk-17.8.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-17.7.0.orig/res/ari/resource_bridges.h
-+++ asterisk-17.7.0/res/ari/resource_bridges.h
+--- asterisk-17.8.0.orig/res/ari/resource_bridges.h
++++ asterisk-17.8.0/res/ari/resource_bridges.h
 @@ -154,6 +154,8 @@ struct ast_ari_bridges_add_channel_args
  	int absorb_dtmf;
  	/*! Mute audio from this channel, preventing it to pass through to the bridge */
@@ -57,10 +57,10 @@ Index: asterisk-17.7.0/res/ari/resource_bridges.h
  };
  /*!
   * \brief Body parsing function for /bridges/{bridgeId}/addChannel.
-Index: asterisk-17.7.0/res/res_ari_bridges.c
+Index: asterisk-17.8.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-17.7.0.orig/res/res_ari_bridges.c
-+++ asterisk-17.7.0/res/res_ari_bridges.c
+--- asterisk-17.8.0.orig/res/res_ari_bridges.c
++++ asterisk-17.8.0/res/res_ari_bridges.c
 @@ -440,6 +440,10 @@ int ast_ari_bridges_add_channel_parse_bo
  	if (field) {
  		args->mute = ast_json_is_true(field);
@@ -82,10 +82,10 @@ Index: asterisk-17.7.0/res/res_ari_bridges.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-17.7.0/res/stasis/control.c
+Index: asterisk-17.8.0/res/stasis/control.c
 ===================================================================
---- asterisk-17.7.0.orig/res/stasis/control.c
-+++ asterisk-17.7.0/res/stasis/control.c
+--- asterisk-17.8.0.orig/res/stasis/control.c
++++ asterisk-17.8.0/res/stasis/control.c
 @@ -1285,6 +1285,7 @@ int control_swap_channel_in_bridge(struc
  {
  	int res;
@@ -126,10 +126,10 @@ Index: asterisk-17.7.0/res/stasis/control.c
  void control_flush_queue(struct stasis_app_control *control)
  {
  	struct ao2_iterator iter;
-Index: asterisk-17.7.0/rest-api/api-docs/bridges.json
+Index: asterisk-17.8.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-17.7.0.orig/rest-api/api-docs/bridges.json
-+++ asterisk-17.7.0/rest-api/api-docs/bridges.json
+--- asterisk-17.8.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-17.8.0/rest-api/api-docs/bridges.json
 @@ -191,6 +191,15 @@
  							"allowMultiple": false,
  							"dataType": "boolean",

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-17.7.0/contrib/scripts/astgenkey
+Index: asterisk-17.8.0/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-17.7.0.orig/contrib/scripts/astgenkey
-+++ asterisk-17.7.0/contrib/scripts/astgenkey
+--- asterisk-17.8.0.orig/contrib/scripts/astgenkey
++++ asterisk-17.8.0/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,10 +3,10 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-17.7.0/Makefile
+Index: asterisk-17.8.0/Makefile
 ===================================================================
---- asterisk-17.7.0.orig/Makefile
-+++ asterisk-17.7.0/Makefile
+--- asterisk-17.8.0.orig/Makefile
++++ asterisk-17.8.0/Makefile
 @@ -434,7 +434,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-17.7.0/res/ari.make
+Index: asterisk-17.8.0/res/ari.make
 ===================================================================
---- asterisk-17.7.0.orig/res/ari.make
-+++ asterisk-17.7.0/res/ari.make
+--- asterisk-17.8.0.orig/res/ari.make
++++ asterisk-17.8.0/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-17.7.0/res/ari/resource_wazo.c
+Index: asterisk-17.8.0/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-17.7.0/res/ari/resource_wazo.c
++++ asterisk-17.8.0/res/ari/resource_wazo.c
 @@ -0,0 +1,409 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -421,10 +421,10 @@ Index: asterisk-17.7.0/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-17.7.0/res/ari/resource_wazo.h
+Index: asterisk-17.8.0/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-17.7.0/res/ari/resource_wazo.h
++++ asterisk-17.8.0/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -626,10 +626,10 @@ Index: asterisk-17.7.0/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-17.7.0/res/res_ari_wazo.c
+Index: asterisk-17.8.0/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-17.7.0/res/res_ari_wazo.c
++++ asterisk-17.8.0/res/res_ari_wazo.c
 @@ -0,0 +1,596 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1227,10 +1227,10 @@ Index: asterisk-17.7.0/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-17.7.0/rest-api/api-docs/wazo.json
+Index: asterisk-17.8.0/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-17.7.0/rest-api/api-docs/wazo.json
++++ asterisk-17.8.0/rest-api/api-docs/wazo.json
 @@ -0,0 +1,300 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1532,10 +1532,10 @@ Index: asterisk-17.7.0/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-17.7.0/rest-api/resources.json
+Index: asterisk-17.8.0/rest-api/resources.json
 ===================================================================
---- asterisk-17.7.0.orig/rest-api/resources.json
-+++ asterisk-17.7.0/rest-api/resources.json
+--- asterisk-17.8.0.orig/rest-api/resources.json
++++ asterisk-17.8.0/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1547,10 +1547,10 @@ Index: asterisk-17.7.0/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-17.7.0/include/asterisk/app.h
+Index: asterisk-17.8.0/include/asterisk/app.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/app.h
-+++ asterisk-17.7.0/include/asterisk/app.h
+--- asterisk-17.8.0.orig/include/asterisk/app.h
++++ asterisk-17.8.0/include/asterisk/app.h
 @@ -533,6 +533,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1640,10 +1640,10 @@ Index: asterisk-17.7.0/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-17.7.0/main/app.c
+Index: asterisk-17.8.0/main/app.c
 ===================================================================
---- asterisk-17.7.0.orig/main/app.c
-+++ asterisk-17.7.0/main/app.c
+--- asterisk-17.8.0.orig/main/app.c
++++ asterisk-17.8.0/main/app.c
 @@ -809,6 +809,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1703,10 +1703,10 @@ Index: asterisk-17.7.0/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-17.7.0/apps/app_voicemail.c
+Index: asterisk-17.8.0/apps/app_voicemail.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_voicemail.c
-+++ asterisk-17.7.0/apps/app_voicemail.c
+--- asterisk-17.8.0.orig/apps/app_voicemail.c
++++ asterisk-17.8.0/apps/app_voicemail.c
 @@ -580,6 +580,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
@@ -1741,7 +1741,7 @@ Index: asterisk-17.7.0/apps/app_voicemail.c
  	RETRIEVE(fn, -1, ext, context);
  	if (ast_fileexists(fn, NULL, NULL) > 0) {
  		res = ast_stream_and_wait(chan, fn, ecodes);
-@@ -15130,6 +15143,10 @@ static const struct ast_vm_functions vm_
+@@ -15118,6 +15131,10 @@ static const struct ast_vm_functions vm_
  	.msg_remove = vm_msg_remove,
  	.msg_forward = vm_msg_forward,
  	.msg_play = vm_msg_play,
@@ -1752,7 +1752,7 @@ Index: asterisk-17.7.0/apps/app_voicemail.c
  };
  
  static const struct ast_vm_greeter_functions vm_greeter_table = {
-@@ -16698,6 +16715,191 @@ play2_msg_cleanup:
+@@ -16686,6 +16703,191 @@ play2_msg_cleanup:
  	return res;
  }
  
@@ -1944,10 +1944,10 @@ Index: asterisk-17.7.0/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-17.7.0/main/http.c
+Index: asterisk-17.8.0/main/http.c
 ===================================================================
---- asterisk-17.7.0.orig/main/http.c
-+++ asterisk-17.7.0/main/http.c
+--- asterisk-17.8.0.orig/main/http.c
++++ asterisk-17.8.0/main/http.c
 @@ -82,7 +82,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */

--- a/debian/patches/wazo_bridge_variables
+++ b/debian/patches/wazo_bridge_variables
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/include/asterisk/bridge.h
+Index: asterisk-17.8.0/include/asterisk/bridge.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/bridge.h
-+++ asterisk-17.7.0/include/asterisk/bridge.h
+--- asterisk-17.8.0.orig/include/asterisk/bridge.h
++++ asterisk-17.8.0/include/asterisk/bridge.h
 @@ -253,6 +253,31 @@ typedef void (*ast_bridge_notify_masquer
  typedef int (*ast_bridge_merge_priority_fn)(struct ast_bridge *self);
  
@@ -85,10 +85,10 @@ Index: asterisk-17.7.0/include/asterisk/bridge.h
  #if defined(__cplusplus) || defined(c_plusplus)
  }
  #endif
-Index: asterisk-17.7.0/main/bridge.c
+Index: asterisk-17.8.0/main/bridge.c
 ===================================================================
---- asterisk-17.7.0.orig/main/bridge.c
-+++ asterisk-17.7.0/main/bridge.c
+--- asterisk-17.8.0.orig/main/bridge.c
++++ asterisk-17.8.0/main/bridge.c
 @@ -118,6 +118,8 @@
  #include "asterisk/core_local.h"
  #include "asterisk/core_unreal.h"
@@ -151,10 +151,10 @@ Index: asterisk-17.7.0/main/bridge.c
  static int manager_bridge_tech_list(struct mansession *s, const struct message *m)
  {
  	const char *id = astman_get_header(m, "ActionID");
-Index: asterisk-17.7.0/res/ari/resource_bridges.c
+Index: asterisk-17.8.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-17.7.0.orig/res/ari/resource_bridges.c
-+++ asterisk-17.7.0/res/ari/resource_bridges.c
+--- asterisk-17.8.0.orig/res/ari/resource_bridges.c
++++ asterisk-17.8.0/res/ari/resource_bridges.c
 @@ -44,6 +44,10 @@
  #include "asterisk/file.h"
  #include "asterisk/musiconhold.h"
@@ -288,10 +288,10 @@ Index: asterisk-17.7.0/res/ari/resource_bridges.c
 +	ast_ari_response_ok(response, response->message);
 +}
 \ No newline at end of file
-Index: asterisk-17.7.0/res/ari/resource_bridges.h
+Index: asterisk-17.8.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-17.7.0.orig/res/ari/resource_bridges.h
-+++ asterisk-17.7.0/res/ari/resource_bridges.h
+--- asterisk-17.8.0.orig/res/ari/resource_bridges.h
++++ asterisk-17.8.0/res/ari/resource_bridges.h
 @@ -395,5 +395,59 @@ int ast_ari_bridges_record_parse_body(
   * \param[out] response HTTP response
   */
@@ -352,10 +352,10 @@ Index: asterisk-17.7.0/res/ari/resource_bridges.h
 +void ast_ari_bridges_set_bridge_var(struct ast_variable *headers, struct ast_ari_bridges_set_bridge_var_args *args, struct ast_ari_response *response);
  
  #endif /* _ASTERISK_RESOURCE_BRIDGES_H */
-Index: asterisk-17.7.0/res/res_ari_bridges.c
+Index: asterisk-17.8.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-17.7.0.orig/res/res_ari_bridges.c
-+++ asterisk-17.7.0/res/res_ari_bridges.c
+--- asterisk-17.8.0.orig/res/res_ari_bridges.c
++++ asterisk-17.8.0/res/res_ari_bridges.c
 @@ -1461,6 +1461,179 @@ static void ast_ari_bridges_record_cb(
  fin: __attribute__((unused))
  	return;
@@ -564,10 +564,10 @@ Index: asterisk-17.7.0/res/res_ari_bridges.c
  };
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges = {
-Index: asterisk-17.7.0/rest-api/api-docs/bridges.json
+Index: asterisk-17.8.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-17.7.0.orig/rest-api/api-docs/bridges.json
-+++ asterisk-17.7.0/rest-api/api-docs/bridges.json
+--- asterisk-17.8.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-17.8.0/rest-api/api-docs/bridges.json
 @@ -574,7 +574,6 @@
  							"reason": "Bridge not in a Stasis application"
  						}
@@ -685,10 +685,10 @@ Index: asterisk-17.7.0/rest-api/api-docs/bridges.json
  				}
  			}
  		}
-Index: asterisk-17.7.0/include/asterisk/stasis_bridges.h
+Index: asterisk-17.8.0/include/asterisk/stasis_bridges.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/stasis_bridges.h
-+++ asterisk-17.7.0/include/asterisk/stasis_bridges.h
+--- asterisk-17.8.0.orig/include/asterisk/stasis_bridges.h
++++ asterisk-17.8.0/include/asterisk/stasis_bridges.h
 @@ -94,6 +94,9 @@ struct ast_bridge_merge_message {
  	struct ast_bridge_snapshot *to;		/*!< Bridge to which channels will be added during the merge */
  };
@@ -717,10 +717,10 @@ Index: asterisk-17.7.0/include/asterisk/stasis_bridges.h
   * \brief Blob of data associated with a bridge.
   *
   * The \c blob is actually a JSON object of structured data. It has a "type" field
-Index: asterisk-17.7.0/main/stasis_bridges.c
+Index: asterisk-17.8.0/main/stasis_bridges.c
 ===================================================================
---- asterisk-17.7.0.orig/main/stasis_bridges.c
-+++ asterisk-17.7.0/main/stasis_bridges.c
+--- asterisk-17.8.0.orig/main/stasis_bridges.c
++++ asterisk-17.8.0/main/stasis_bridges.c
 @@ -37,6 +37,7 @@
  #include "asterisk/stasis_channels.h"
  #include "asterisk/bridge.h"
@@ -861,10 +861,10 @@ Index: asterisk-17.7.0/main/stasis_bridges.c
  
  	return res;
  }
-Index: asterisk-17.7.0/rest-api/api-docs/events.json
+Index: asterisk-17.8.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-17.7.0.orig/rest-api/api-docs/events.json
-+++ asterisk-17.7.0/rest-api/api-docs/events.json
+--- asterisk-17.8.0.orig/rest-api/api-docs/events.json
++++ asterisk-17.8.0/rest-api/api-docs/events.json
 @@ -162,6 +162,7 @@
  				"ApplicationMoveFailed",
  				"ApplicationReplaced",

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/res/res_pjsip/location.c
+Index: asterisk-17.8.0/res/res_pjsip/location.c
 ===================================================================
---- asterisk-17.7.0.orig/res/res_pjsip/location.c
-+++ asterisk-17.7.0/res/res_pjsip/location.c
+--- asterisk-17.8.0.orig/res/res_pjsip/location.c
++++ asterisk-17.8.0/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,10 +41,10 @@ Index: asterisk-17.7.0/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-17.7.0/res/res_pjsip_registrar.c
+Index: asterisk-17.8.0/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-17.7.0.orig/res/res_pjsip_registrar.c
-+++ asterisk-17.7.0/res/res_pjsip_registrar.c
+--- asterisk-17.8.0.orig/res/res_pjsip_registrar.c
++++ asterisk-17.8.0/res/res_pjsip_registrar.c
 @@ -758,6 +758,9 @@ static void register_aor_core(pjsip_rx_d
  
  		if (!contact) {
@@ -76,10 +76,10 @@ Index: asterisk-17.7.0/res/res_pjsip_registrar.c
  			if (!contact) {
  				ast_log(LOG_ERROR, "Unable to bind contact '%s' to AOR '%s'\n",
  					contact_uri, aor_name);
-Index: asterisk-17.7.0/include/asterisk/res_pjsip.h
+Index: asterisk-17.8.0/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/res_pjsip.h
-+++ asterisk-17.7.0/include/asterisk/res_pjsip.h
+--- asterisk-17.8.0.orig/include/asterisk/res_pjsip.h
++++ asterisk-17.8.0/include/asterisk/res_pjsip.h
 @@ -296,6 +296,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
@@ -98,10 +98,10 @@ Index: asterisk-17.7.0/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-17.7.0/res/res_pjsip.c
+Index: asterisk-17.8.0/res/res_pjsip.c
 ===================================================================
---- asterisk-17.7.0.orig/res/res_pjsip.c
-+++ asterisk-17.7.0/res/res_pjsip.c
+--- asterisk-17.8.0.orig/res/res_pjsip.c
++++ asterisk-17.8.0/res/res_pjsip.c
 @@ -1521,6 +1521,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/apps/app_queue.c
+Index: asterisk-17.8.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_queue.c
-+++ asterisk-17.7.0/apps/app_queue.c
+--- asterisk-17.8.0.orig/apps/app_queue.c
++++ asterisk-17.8.0/apps/app_queue.c
 @@ -2233,6 +2233,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;
@@ -21,7 +21,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	}
  
  	agent = ast_multi_channel_blob_get_channel(obj, "agent");
-@@ -6084,13 +6096,14 @@ static void send_agent_complete(const ch
+@@ -6085,13 +6097,14 @@ static void send_agent_complete(const ch
  		break;
  	}
  

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,8 +1,8 @@
-Index: asterisk-17.7.0/apps/app_queue.c
+Index: asterisk-17.8.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_queue.c
-+++ asterisk-17.7.0/apps/app_queue.c
-@@ -6067,7 +6067,7 @@ enum agent_complete_reason {
+--- asterisk-17.8.0.orig/apps/app_queue.c
++++ asterisk-17.8.0/apps/app_queue.c
+@@ -6068,7 +6068,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,
  	struct ast_channel_snapshot *peer, const struct member *member, time_t holdstart,
@@ -11,7 +11,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  {
  	const char *reason = NULL;	/* silence dumb compilers */
  	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
-@@ -6084,16 +6084,21 @@ static void send_agent_complete(const ch
+@@ -6085,16 +6085,21 @@ static void send_agent_complete(const ch
  		break;
  	}
  
@@ -34,7 +34,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  }
  
  static void queue_agent_cb(void *userdata, struct stasis_subscription *sub,
-@@ -6390,7 +6395,7 @@ static void handle_blind_transfer(void *
+@@ -6391,7 +6396,7 @@ static void handle_blind_transfer(void *
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -43,7 +43,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -6449,7 +6454,7 @@ static void handle_attended_transfer(voi
+@@ -6450,7 +6455,7 @@ static void handle_attended_transfer(voi
  	log_attended_transfer(queue_data, atxfer_msg);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -52,7 +52,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -6650,7 +6655,7 @@ static void handle_hangup(void *userdata
+@@ -6651,7 +6656,7 @@ static void handle_hangup(void *userdata
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/main/stasis_channels.c
+Index: asterisk-17.8.0/main/stasis_channels.c
 ===================================================================
---- asterisk-17.7.0.orig/main/stasis_channels.c
-+++ asterisk-17.7.0/main/stasis_channels.c
+--- asterisk-17.8.0.orig/main/stasis_channels.c
++++ asterisk-17.8.0/main/stasis_channels.c
 @@ -1573,6 +1573,47 @@ static struct ast_json *unhold_to_json(s
  		"channel", json_channel);
  }
@@ -65,10 +65,10 @@ Index: asterisk-17.7.0/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_agent_login_type,
-Index: asterisk-17.7.0/rest-api/api-docs/events.json
+Index: asterisk-17.8.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-17.7.0.orig/rest-api/api-docs/events.json
-+++ asterisk-17.7.0/rest-api/api-docs/events.json
+--- asterisk-17.8.0.orig/rest-api/api-docs/events.json
++++ asterisk-17.8.0/rest-api/api-docs/events.json
 @@ -189,7 +189,9 @@
  				"StasisStart",
  				"TextMessageReceived",

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/res/ari/resource_channels.c
+Index: asterisk-17.8.0/res/ari/resource_channels.c
 ===================================================================
---- asterisk-17.7.0.orig/res/ari/resource_channels.c
-+++ asterisk-17.7.0/res/ari/resource_channels.c
+--- asterisk-17.8.0.orig/res/ari/resource_channels.c
++++ asterisk-17.8.0/res/ari/resource_channels.c
 @@ -1553,6 +1553,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-17.7.0/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-17.7.0/res/ari/resource_channels.h
+Index: asterisk-17.8.0/res/ari/resource_channels.h
 ===================================================================
---- asterisk-17.7.0.orig/res/ari/resource_channels.h
-+++ asterisk-17.7.0/res/ari/resource_channels.h
+--- asterisk-17.8.0.orig/res/ari/resource_channels.h
++++ asterisk-17.8.0/res/ari/resource_channels.h
 @@ -693,6 +693,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *variable;
  	/*! The value to set the variable to */
@@ -37,10 +37,10 @@ Index: asterisk-17.7.0/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-17.7.0/res/res_ari_channels.c
+Index: asterisk-17.8.0/res/res_ari_channels.c
 ===================================================================
---- asterisk-17.7.0.orig/res/res_ari_channels.c
-+++ asterisk-17.7.0/res/res_ari_channels.c
+--- asterisk-17.8.0.orig/res/res_ari_channels.c
++++ asterisk-17.8.0/res/res_ari_channels.c
 @@ -2372,6 +2372,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->value = ast_json_string_get(field);
@@ -62,10 +62,10 @@ Index: asterisk-17.7.0/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-17.7.0/rest-api/api-docs/channels.json
+Index: asterisk-17.8.0/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-17.7.0.orig/rest-api/api-docs/channels.json
-+++ asterisk-17.7.0/rest-api/api-docs/channels.json
+--- asterisk-17.8.0.orig/rest-api/api-docs/channels.json
++++ asterisk-17.8.0/rest-api/api-docs/channels.json
 @@ -1478,6 +1478,15 @@
  							"required": false,
  							"allowMultiple": false,

--- a/debian/patches/xivo_banner
+++ b/debian/patches/xivo_banner
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/main/asterisk.c
+Index: asterisk-17.8.0/main/asterisk.c
 ===================================================================
---- asterisk-17.7.0.orig/main/asterisk.c
-+++ asterisk-17.7.0/main/asterisk.c
+--- asterisk-17.8.0.orig/main/asterisk.c
++++ asterisk-17.8.0/main/asterisk.c
 @@ -307,6 +307,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/main/ccss.c
+Index: asterisk-17.8.0/main/ccss.c
 ===================================================================
---- asterisk-17.7.0.orig/main/ccss.c
-+++ asterisk-17.7.0/main/ccss.c
+--- asterisk-17.8.0.orig/main/ccss.c
++++ asterisk-17.8.0/main/ccss.c
 @@ -2669,6 +2669,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/include/asterisk/channel.h
+Index: asterisk-17.8.0/include/asterisk/channel.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/channel.h
-+++ asterisk-17.7.0/include/asterisk/channel.h
+--- asterisk-17.8.0.orig/include/asterisk/channel.h
++++ asterisk-17.8.0/include/asterisk/channel.h
 @@ -4514,6 +4514,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
@@ -21,10 +21,10 @@ Index: asterisk-17.7.0/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-17.7.0/main/channel.c
+Index: asterisk-17.8.0/main/channel.c
 ===================================================================
---- asterisk-17.7.0.orig/main/channel.c
-+++ asterisk-17.7.0/main/channel.c
+--- asterisk-17.8.0.orig/main/channel.c
++++ asterisk-17.8.0/main/channel.c
 @@ -11063,3 +11063,8 @@ void ast_channel_clear_flag(struct ast_c
  	ast_clear_flag(ast_channel_flags(chan), flag);
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/main/features.c
+Index: asterisk-17.8.0/main/features.c
 ===================================================================
---- asterisk-17.7.0.orig/main/features.c
-+++ asterisk-17.7.0/main/features.c
+--- asterisk-17.8.0.orig/main/features.c
++++ asterisk-17.8.0/main/features.c
 @@ -658,6 +658,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/include/asterisk/file.h
+Index: asterisk-17.8.0/include/asterisk/file.h
 ===================================================================
---- asterisk-17.7.0.orig/include/asterisk/file.h
-+++ asterisk-17.7.0/include/asterisk/file.h
+--- asterisk-17.8.0.orig/include/asterisk/file.h
++++ asterisk-17.8.0/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,10 +10,10 @@ Index: asterisk-17.7.0/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-17.7.0/main/bridge_basic.c
+Index: asterisk-17.8.0/main/bridge_basic.c
 ===================================================================
---- asterisk-17.7.0.orig/main/bridge_basic.c
-+++ asterisk-17.7.0/main/bridge_basic.c
+--- asterisk-17.8.0.orig/main/bridge_basic.c
++++ asterisk-17.8.0/main/bridge_basic.c
 @@ -3183,7 +3183,7 @@ static int grab_transfer(struct ast_chan
  	ast_channel_unlock(chan);
  

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,9 +1,9 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-17.7.0/apps/app_queue.c
+Index: asterisk-17.8.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_queue.c
-+++ asterisk-17.7.0/apps/app_queue.c
-@@ -9987,6 +9987,7 @@ static int manager_queues_summary(struct
+--- asterisk-17.8.0.orig/apps/app_queue.c
++++ asterisk-17.8.0/apps/app_queue.c
+@@ -9988,6 +9988,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;
  	int qmemcount = 0;
@@ -11,7 +11,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	int qmemavail = 0;
  	int qchancount = 0;
  	int qlongestholdtime = 0;
-@@ -10014,6 +10015,7 @@ static int manager_queues_summary(struct
+@@ -10015,6 +10016,7 @@ static int manager_queues_summary(struct
  		if (ast_strlen_zero(queuefilter) || !strcasecmp(q->name, queuefilter)) {
  			/* Reset the necessary local variables if no queuefilter is set*/
  			qmemcount = 0;
@@ -19,7 +19,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  			qmemavail = 0;
  			qchancount = 0;
  			qlongestholdtime = 0;
-@@ -10027,6 +10029,9 @@ static int manager_queues_summary(struct
+@@ -10028,6 +10030,9 @@ static int manager_queues_summary(struct
  						++qmemavail;
  					}
  				}
@@ -29,7 +29,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  				ao2_ref(mem, -1);
  			}
  			ao2_iterator_destroy(&mem_iter);
-@@ -10040,13 +10045,14 @@ static int manager_queues_summary(struct
+@@ -10041,13 +10046,14 @@ static int manager_queues_summary(struct
  				"Queue: %s\r\n"
  				"LoggedIn: %d\r\n"
  				"Available: %d\r\n"

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/apps/app_queue.c
+Index: asterisk-17.8.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_queue.c
-+++ asterisk-17.7.0/apps/app_queue.c
+--- asterisk-17.8.0.orig/apps/app_queue.c
++++ asterisk-17.8.0/apps/app_queue.c
 @@ -1576,6 +1576,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
@@ -45,7 +45,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  			ast_channel_publish_cached_blob(qe->chan, queue_caller_leave_type(), blob);
  			ast_debug(1, "Queue '%s' Leave, Channel '%s'\n", q->name, ast_channel_name(qe->chan));
  			/* Take us out of the queue */
-@@ -8552,6 +8568,8 @@ static int queue_exec(struct ast_channel
+@@ -8553,6 +8569,8 @@ static int queue_exec(struct ast_channel
  	} else {
  		raise_penalty = INT_MAX;
  	}

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/apps/app_queue.c
+Index: asterisk-17.8.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_queue.c
-+++ asterisk-17.7.0/apps/app_queue.c
+--- asterisk-17.8.0.orig/apps/app_queue.c
++++ asterisk-17.8.0/apps/app_queue.c
 @@ -4279,7 +4279,7 @@ static int say_position(struct queue_ent
  		}
  
@@ -11,7 +11,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  			if (res) {
  				goto playout;
  			}
-@@ -7204,7 +7204,7 @@ static int try_calling(struct queue_ent
+@@ -7205,7 +7205,7 @@ static int try_calling(struct queue_ent
  						holdtime = labs((now - qe->start) / 60);
  						holdtimesecs = labs((now - qe->start) % 60);
  						if (holdtime > 0) {

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,8 +1,8 @@
-Index: asterisk-17.7.0/apps/app_queue.c
+Index: asterisk-17.8.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_queue.c
-+++ asterisk-17.7.0/apps/app_queue.c
-@@ -6423,10 +6423,10 @@ static void handle_blind_transfer(void *
+--- asterisk-17.8.0.orig/apps/app_queue.c
++++ asterisk-17.8.0/apps/app_queue.c
+@@ -6424,10 +6424,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
@@ -15,7 +15,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -6482,10 +6482,10 @@ static void handle_attended_transfer(voi
+@@ -6483,10 +6483,10 @@ static void handle_attended_transfer(voi
  	ast_debug(3, "Detected attended transfer in queue %s\n", queue_data->queue->name);
  	log_attended_transfer(queue_data, atxfer_msg);
  
@@ -28,7 +28,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -6683,10 +6683,10 @@ static void handle_hangup(void *userdata
+@@ -6684,10 +6684,10 @@ static void handle_hangup(void *userdata
  		(long) (queue_data->starttime - queue_data->holdstart),
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/main/channel.c
+Index: asterisk-17.8.0/main/channel.c
 ===================================================================
---- asterisk-17.7.0.orig/main/channel.c
-+++ asterisk-17.7.0/main/channel.c
+--- asterisk-17.8.0.orig/main/channel.c
++++ asterisk-17.8.0/main/channel.c
 @@ -4854,7 +4854,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_sip_tel_uri
+++ b/debian/patches/xivo_sip_tel_uri
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/channels/sip/reqresp_parser.c
+Index: asterisk-17.8.0/channels/sip/reqresp_parser.c
 ===================================================================
---- asterisk-17.7.0.orig/channels/sip/reqresp_parser.c
-+++ asterisk-17.7.0/channels/sip/reqresp_parser.c
+--- asterisk-17.8.0.orig/channels/sip/reqresp_parser.c
++++ asterisk-17.8.0/channels/sip/reqresp_parser.c
 @@ -925,7 +925,7 @@ int get_name_and_number(const char *hdr,
  	tmp_number = get_in_brackets(header);
  

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,7 +1,7 @@
-Index: asterisk-17.7.0/apps/app_queue.c
+Index: asterisk-17.8.0/apps/app_queue.c
 ===================================================================
---- asterisk-17.7.0.orig/apps/app_queue.c
-+++ asterisk-17.7.0/apps/app_queue.c
+--- asterisk-17.8.0.orig/apps/app_queue.c
++++ asterisk-17.8.0/apps/app_queue.c
 @@ -1403,6 +1403,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
@@ -527,10 +527,10 @@ Index: asterisk-17.7.0/apps/app_queue.c
  
 -			if ((status = get_member_status(qe->parent, qe->max_penalty, qe->min_penalty, qe->raise_penalty, qe->parent->leavewhenempty, 0))) {
 +			if ((status = get_member_status(qe->parent, qe->max_penalty, qe->min_penalty, qe->raise_penalty, qe->parent->leavewhenempty, 0, qe))) {
+ 				record_abandoned(qe);
  				*reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(qe->parent->name, ast_channel_uniqueid(qe->chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe->pos, qe->opos, (long) (time(NULL) - qe->start));
- 				res = -1;
-@@ -5694,6 +5892,13 @@ static int wait_our_turn(struct queue_en
+@@ -5695,6 +5893,13 @@ static int wait_our_turn(struct queue_en
  			*reason = QUEUE_TIMEOUT;
  			break;
  		}
@@ -544,7 +544,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	}
  
  	return res;
-@@ -6940,6 +7145,7 @@ static int try_calling(struct queue_ent
+@@ -6941,6 +7146,7 @@ static int try_calling(struct queue_ent
  		ao2_unlock(qe->parent);
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
@@ -552,7 +552,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  		hangupcalls(qe, outgoing, peer, qe->cancel_answered_elsewhere);
  		outgoing = NULL;
  		if (announce || qe->parent->reportholdtime || qe->parent->memberdelay) {
-@@ -7262,7 +7468,7 @@ static struct member *interface_exists(s
+@@ -7263,7 +7469,7 @@ static struct member *interface_exists(s
  
  /*! \brief Dump all members in a specific queue to the database
   * \code
@@ -561,7 +561,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
   * \endcode
   */
  static void dump_queue_members(struct call_queue *pm_queue)
-@@ -7288,13 +7494,14 @@ static void dump_queue_members(struct ca
+@@ -7289,13 +7495,14 @@ static void dump_queue_members(struct ca
  			continue;
  		}
  
@@ -577,7 +577,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  			cur_member->reason_paused,
  			cur_member->wrapuptime);
  
-@@ -7326,6 +7533,7 @@ static int remove_from_queue(const char
+@@ -7327,6 +7534,7 @@ static int remove_from_queue(const char
  		.name = queuename,
  	};
  	struct member *mem, tmpmem;
@@ -585,7 +585,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	int res = RES_NOSUCHQUEUE;
  
  	ast_copy_string(tmpmem.interface, interface, sizeof(tmpmem.interface));
-@@ -7345,13 +7553,20 @@ static int remove_from_queue(const char
+@@ -7346,13 +7554,20 @@ static int remove_from_queue(const char
  			queue_publish_member_blob(queue_member_removed_type(), queue_member_blob_create(q, mem));
  
  			member_remove_from_queue(q, mem);
@@ -607,7 +607,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -7373,7 +7588,7 @@ static int remove_from_queue(const char
+@@ -7374,7 +7589,7 @@ static int remove_from_queue(const char
   * \retval RES_EXISTS queue exists but no members
   * \retval RES_OUT_OF_MEMORY queue exists but not enough memory to create member
  */
@@ -616,7 +616,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  {
  	struct call_queue *q;
  	struct member *new_member, *old_member;
-@@ -7387,15 +7602,16 @@ static int add_to_queue(const char *queu
+@@ -7388,15 +7603,16 @@ static int add_to_queue(const char *queu
  
  	ao2_lock(q);
  	if ((old_member = interface_exists(q, interface)) == NULL) {
@@ -635,7 +635,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -7514,16 +7730,17 @@ static void set_queue_member_pause(struc
+@@ -7515,16 +7731,17 @@ static void set_queue_member_pause(struc
  		dump_queue_members(q);
  	}
  
@@ -655,7 +655,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  
  	publish_queue_member_pause(q, mem, reason);
  }
-@@ -7774,6 +7991,7 @@ static void reload_queue_members(void)
+@@ -7775,6 +7992,7 @@ static void reload_queue_members(void)
  	char *member;
  	char *interface;
  	char *membername = NULL;
@@ -663,7 +663,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	char *state_interface;
  	char *penalty_tok;
  	int penalty = 0;
-@@ -7828,6 +8046,7 @@ static void reload_queue_members(void)
+@@ -7829,6 +8047,7 @@ static void reload_queue_members(void)
  			paused_tok = strsep(&member, ";");
  			membername = strsep(&member, ";");
  			state_interface = strsep(&member, ";");
@@ -671,7 +671,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  			reason_paused = strsep(&member, ";");
  			wrapuptime_tok = strsep(&member, ";");
  
-@@ -7862,7 +8081,7 @@ static void reload_queue_members(void)
+@@ -7863,7 +8082,7 @@ static void reload_queue_members(void)
  			ast_debug(1, "Reload Members: Queue: %s  Member: %s  Name: %s  Penalty: %d  Paused: %d ReasonPause: %s  Wrapuptime: %d\n",
  			              queue_name, interface, membername, penalty, paused, reason_paused, wrapuptime);
  
@@ -680,7 +680,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  				ast_log(LOG_ERROR, "Out of Memory when reloading persistent queue member\n");
  				break;
  			}
-@@ -8033,12 +8252,13 @@ static int aqm_exec(struct ast_channel *
+@@ -8034,12 +8253,13 @@ static int aqm_exec(struct ast_channel *
  		AST_APP_ARG(membername);
  		AST_APP_ARG(state_interface);
  		AST_APP_ARG(wrapuptime);
@@ -695,7 +695,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8072,7 +8292,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8073,7 +8293,7 @@ static int aqm_exec(struct ast_channel *
  		wrapuptime = 0;
  	}
  
@@ -704,7 +704,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(args.membername) || !log_membername_as_agent) {
  			ast_queue_log(args.queuename, ast_channel_uniqueid(chan), args.interface, "ADDMEMBER", "%s", "");
-@@ -8208,6 +8428,7 @@ static int queue_exec(struct ast_channel
+@@ -8209,6 +8429,7 @@ static int queue_exec(struct ast_channel
  		AST_APP_ARG(gosub);
  		AST_APP_ARG(rule);
  		AST_APP_ARG(position);
@@ -712,7 +712,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	);
  	/* Our queue entry */
  	struct queue_ent qe = { 0 };
-@@ -8216,7 +8437,7 @@ static int queue_exec(struct ast_channel
+@@ -8217,7 +8438,7 @@ static int queue_exec(struct ast_channel
  	int max_forwards;
  
  	if (ast_strlen_zero(data)) {
@@ -721,7 +721,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8343,6 +8564,9 @@ static int queue_exec(struct ast_channel
+@@ -8344,6 +8565,9 @@ static int queue_exec(struct ast_channel
  	qe.max_penalty = max_penalty;
  	qe.min_penalty = min_penalty;
  	qe.raise_penalty = raise_penalty;
@@ -731,7 +731,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	qe.last_pos_said = 0;
  	qe.last_pos = 0;
  	qe.last_periodic_announce_time = time(NULL);
-@@ -8383,6 +8607,18 @@ check_turns:
+@@ -8384,6 +8608,18 @@ check_turns:
  		ast_moh_start(chan, qe.moh, NULL);
  	}
  
@@ -750,7 +750,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	/* This is the wait loop for callers 2 through maxlen */
  	res = wait_our_turn(&qe, ringing, &reason);
  	if (res) {
-@@ -8447,7 +8683,7 @@ check_turns:
+@@ -8448,7 +8684,7 @@ check_turns:
  
  		if (qe.parent->leavewhenempty) {
  			int status = 0;
@@ -759,7 +759,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  				record_abandoned(&qe);
  				reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(args.queuename, ast_channel_uniqueid(chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe.pos, qe.opos, (long)(time(NULL) - qe.start));
-@@ -8535,6 +8771,16 @@ stop:
+@@ -8536,6 +8772,16 @@ stop:
  	if (reason != QUEUE_UNKNOWN)
  		set_queue_result(chan, reason);
  
@@ -776,7 +776,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	/*
  	 * every queue_ent is given a reference to it's parent
  	 * call_queue when it joins the queue.  This ref must be taken
-@@ -9190,6 +9436,7 @@ static int reload_queue_rules(int reload
+@@ -9191,6 +9437,7 @@ static int reload_queue_rules(int reload
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -784,7 +784,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  /*! Set the global queue parameters as defined in the "general" section of queues.conf */
  static void queue_set_global_params(struct ast_config *cfg)
  {
-@@ -9235,7 +9482,7 @@ static void queue_set_global_params(stru
+@@ -9236,7 +9483,7 @@ static void queue_set_global_params(stru
   */
  static void reload_single_member(const char *memberdata, struct call_queue *q)
  {
@@ -793,7 +793,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	char *parse;
  	struct member *cur, *newm;
  	struct member tmpmem;
-@@ -9249,6 +9496,7 @@ static void reload_single_member(const c
+@@ -9250,6 +9497,7 @@ static void reload_single_member(const c
  		AST_APP_ARG(state_interface);
  		AST_APP_ARG(ringinuse);
  		AST_APP_ARG(wrapuptime);
@@ -801,7 +801,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	);
  
  	if (ast_strlen_zero(memberdata)) {
-@@ -9303,6 +9551,10 @@ static void reload_single_member(const c
+@@ -9304,6 +9552,10 @@ static void reload_single_member(const c
  		ringinuse = q->ringinuse;
  	}
  
@@ -812,7 +812,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	if (!ast_strlen_zero(args.wrapuptime)) {
  		tmp = args.wrapuptime;
  		ast_strip(tmp);
-@@ -9318,7 +9570,7 @@ static void reload_single_member(const c
+@@ -9319,7 +9571,7 @@ static void reload_single_member(const c
  	ast_copy_string(tmpmem.interface, interface, sizeof(tmpmem.interface));
  	cur = ao2_find(q->members, &tmpmem, OBJ_POINTER);
  
@@ -821,7 +821,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  		newm->wrapuptime = wrapuptime;
  		if (cur) {
  			/* Round Robin Queue Position must be copied if this is replacing an existing member */
-@@ -9334,6 +9586,7 @@ static void reload_single_member(const c
+@@ -9335,6 +9587,7 @@ static void reload_single_member(const c
  		ao2_ref(newm, -1);
  	}
  	newm = NULL;
@@ -829,7 +829,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  
  	if (cur) {
  		ao2_ref(cur, -1);
-@@ -9622,6 +9875,12 @@ static int reload_handler(int reload, st
+@@ -9623,6 +9876,12 @@ static int reload_handler(int reload, st
  	if (ast_test_flag(mask, QUEUE_RELOAD_RULES)) {
  		res |= reload_queue_rules(reload);
  	}
@@ -842,7 +842,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	if (ast_test_flag(mask, QUEUE_RESET_STATS)) {
  		res |= clear_stats(queuename);
  	}
-@@ -9772,6 +10031,8 @@ static char *__queues_show(struct manses
+@@ -9773,6 +10032,8 @@ static char *__queues_show(struct manses
  						mem->status == AST_DEVICE_UNAVAILABLE || mem->status == AST_DEVICE_UNKNOWN ?
  							COLOR_RED : COLOR_GREEN, COLOR_BLACK),
  						ast_devstate2str(mem->status), ast_term_reset());
@@ -851,7 +851,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  				if (mem->calls) {
  					ast_str_append(&out, 0, " has taken %d calls (last was %ld secs ago)",
  						mem->calls, (long) (now - mem->lastcall));
-@@ -9789,8 +10050,32 @@ static char *__queues_show(struct manses
+@@ -9790,8 +10051,32 @@ static char *__queues_show(struct manses
  			struct queue_ent *qe;
  			int pos = 1;
  
@@ -884,7 +884,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  				ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
  					pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
  					(long) (now - qe->start) % 60, qe->prio);
-@@ -10138,11 +10423,12 @@ static int manager_queues_status(struct
+@@ -10139,11 +10424,12 @@ static int manager_queues_status(struct
  						"Paused: %d\r\n"
  						"PausedReason: %s\r\n"
  						"Wrapuptime: %d\r\n"
@@ -898,7 +898,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  					++q_items;
  				}
  				ao2_ref(mem, -1);
-@@ -10187,7 +10473,7 @@ static int manager_queues_status(struct
+@@ -10188,7 +10474,7 @@ static int manager_queues_status(struct
  
  static int manager_add_queue_member(struct mansession *s, const struct message *m)
  {
@@ -907,7 +907,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	int paused, penalty, wrapuptime = 0;
  
  	queuename = astman_get_header(m, "Queue");
-@@ -10197,6 +10483,7 @@ static int manager_add_queue_member(stru
+@@ -10198,6 +10484,7 @@ static int manager_add_queue_member(stru
  	membername = astman_get_header(m, "MemberName");
  	state_interface = astman_get_header(m, "StateInterface");
  	wrapuptime_s = astman_get_header(m, "Wrapuptime");
@@ -915,7 +915,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  
  	if (ast_strlen_zero(queuename)) {
  		astman_send_error(s, m, "'Queue' not specified.");
-@@ -10226,7 +10513,7 @@ static int manager_add_queue_member(stru
+@@ -10227,7 +10514,7 @@ static int manager_add_queue_member(stru
  		paused = abs(ast_true(paused_s));
  	}
  
@@ -924,7 +924,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "MANAGER", interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -10357,6 +10644,14 @@ static int manager_queue_reload(struct m
+@@ -10358,6 +10645,14 @@ static int manager_queue_reload(struct m
  		ast_set_flag(&mask, QUEUE_RELOAD_RULES);
  		header_found = 1;
  	}
@@ -939,7 +939,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	if (!strcasecmp(S_OR(astman_get_header(m, "Parameters"), ""), "yes")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
  		header_found = 1;
-@@ -10526,7 +10821,7 @@ static int manager_change_priority_calle
+@@ -10527,7 +10822,7 @@ static int manager_change_priority_calle
  
  static char *handle_queue_add_member(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
  {
@@ -948,7 +948,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	int penalty;
  
  	switch ( cmd ) {
-@@ -10540,7 +10835,7 @@ static char *handle_queue_add_member(str
+@@ -10541,7 +10836,7 @@ static char *handle_queue_add_member(str
  		return complete_queue_add_member(a->line, a->word, a->pos, a->n);
  	}
  
@@ -957,7 +957,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  		return CLI_SHOWUSAGE;
  	} else if (strcmp(a->argv[4], "to")) {
  		return CLI_SHOWUSAGE;
-@@ -10550,6 +10845,8 @@ static char *handle_queue_add_member(str
+@@ -10551,6 +10846,8 @@ static char *handle_queue_add_member(str
  		return CLI_SHOWUSAGE;
  	} else if ((a->argc == 12) && strcmp(a->argv[10], "state_interface")) {
  		return CLI_SHOWUSAGE;
@@ -966,7 +966,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	}
  
  	queuename = a->argv[5];
-@@ -10576,7 +10873,11 @@ static char *handle_queue_add_member(str
+@@ -10577,7 +10874,11 @@ static char *handle_queue_add_member(str
  		state_interface = a->argv[11];
  	}
  
@@ -979,7 +979,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "CLI", interface, "ADDMEMBER", "%s", "");
-@@ -11101,6 +11402,10 @@ static char *handle_queue_reload(struct
+@@ -11102,6 +11403,10 @@ static char *handle_queue_reload(struct
  		ast_set_flag(&mask, QUEUE_RELOAD_MEMBER);
  	} else if (!strcasecmp(a->argv[2], "parameters")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
@@ -990,7 +990,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  	} else if (!strcasecmp(a->argv[2], "all")) {
  		ast_set_flag(&mask, AST_FLAGS_ALL);
  	}
-@@ -11197,6 +11502,1182 @@ static int qupd_exec(struct ast_channel
+@@ -11198,6 +11503,1182 @@ static int qupd_exec(struct ast_channel
  	return 0;
  }
  
@@ -2173,7 +2173,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  static struct ast_cli_entry cli_queue[] = {
  	AST_CLI_DEFINE(queue_show, "Show status of a specified queue"),
  	AST_CLI_DEFINE(handle_queue_rule_show, "Show the rules defined in queuerules.conf"),
-@@ -11208,11 +12689,10 @@ static struct ast_cli_entry cli_queue[]
+@@ -11209,11 +12690,10 @@ static struct ast_cli_entry cli_queue[]
  	AST_CLI_DEFINE(handle_queue_reload, "Reload queues, members, queue rules, or parameters"),
  	AST_CLI_DEFINE(handle_queue_reset, "Reset statistics for a queue"),
  	AST_CLI_DEFINE(handle_queue_change_priority_caller, "Change priority caller on queue"),
@@ -2187,7 +2187,7 @@ Index: asterisk-17.7.0/apps/app_queue.c
  static int unload_module(void)
  {
  	stasis_message_router_unsubscribe_and_join(agent_router);
-@@ -11436,31 +12916,6 @@ static int load_module(void)
+@@ -11437,31 +12917,6 @@ static int load_module(void)
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -2219,10 +2219,10 @@ Index: asterisk-17.7.0/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-17.7.0/configs/samples/queueskillrules.conf.sample
+Index: asterisk-17.8.0/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-17.7.0/configs/samples/queueskillrules.conf.sample
++++ asterisk-17.8.0/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2287,10 +2287,10 @@ Index: asterisk-17.7.0/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-17.7.0/configs/samples/queueskills.conf.sample
+Index: asterisk-17.8.0/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-17.7.0/configs/samples/queueskills.conf.sample
++++ asterisk-17.8.0/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
The version in the Debian changelog ends with `~wazo2` and the one in the `asterisk-rc` branch is `~wazo1`. This means that this branch can be merged without messing with the changelog when ready.