### PR TITLE
update for Asterisk 18.2.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:18.2.0-1~wazo2) wazo-dev-buster; urgency=medium
+
+  * Asterisk 18.2.0
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 26 Jan 2021 08:14:14 -0500
+
 asterisk (8:18.1.1-1~wazo4) wazo-dev-buster; urgency=medium
 
   * add AMI events MixMonitorStart/Stop/Mute

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-asterisk (8:18.2.0-1~wazo2) wazo-dev-buster; urgency=medium
+asterisk (8:18.2.0-1~wazo3) wazo-dev-buster; urgency=medium
 
   * Asterisk 18.2.0
 

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-18.1.1/contrib/scripts/astgenkey
+Index: asterisk-18.2.0/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-18.1.1.orig/contrib/scripts/astgenkey
-+++ asterisk-18.1.1/contrib/scripts/astgenkey
+--- asterisk-18.2.0.orig/contrib/scripts/astgenkey
++++ asterisk-18.2.0/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,11 +3,11 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-18.1.1/Makefile
+Index: asterisk-18.2.0/Makefile
 ===================================================================
---- asterisk-18.1.1.orig/Makefile
-+++ asterisk-18.1.1/Makefile
-@@ -434,7 +434,6 @@ dist-clean: distclean
+--- asterisk-18.2.0.orig/Makefile
++++ asterisk-18.2.0/Makefile
+@@ -435,7 +435,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	@$(MAKE) -C menuselect dist-clean
@@ -15,7 +15,7 @@ Index: asterisk-18.1.1/Makefile
  	rm -f menuselect.makeopts makeopts menuselect-tree menuselect.makedeps
  	rm -f config.log config.status config.cache
  	rm -rf autom4te.cache
-@@ -444,6 +443,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
+@@ -445,6 +444,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	rm -f doc/asterisk-ng-doxygen
  	rm -f build_tools/menuselect-deps
  

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-18.1.1/res/ari.make
+Index: asterisk-18.2.0/res/ari.make
 ===================================================================
---- asterisk-18.1.1.orig/res/ari.make
-+++ asterisk-18.1.1/res/ari.make
+--- asterisk-18.2.0.orig/res/ari.make
++++ asterisk-18.2.0/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-18.1.1/res/ari/resource_wazo.c
+Index: asterisk-18.2.0/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-18.1.1/res/ari/resource_wazo.c
++++ asterisk-18.2.0/res/ari/resource_wazo.c
 @@ -0,0 +1,409 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -421,10 +421,10 @@ Index: asterisk-18.1.1/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-18.1.1/res/ari/resource_wazo.h
+Index: asterisk-18.2.0/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-18.1.1/res/ari/resource_wazo.h
++++ asterisk-18.2.0/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -626,10 +626,10 @@ Index: asterisk-18.1.1/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-18.1.1/res/res_ari_wazo.c
+Index: asterisk-18.2.0/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-18.1.1/res/res_ari_wazo.c
++++ asterisk-18.2.0/res/res_ari_wazo.c
 @@ -0,0 +1,596 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1227,10 +1227,10 @@ Index: asterisk-18.1.1/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-18.1.1/rest-api/api-docs/wazo.json
+Index: asterisk-18.2.0/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-18.1.1/rest-api/api-docs/wazo.json
++++ asterisk-18.2.0/rest-api/api-docs/wazo.json
 @@ -0,0 +1,300 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1532,10 +1532,10 @@ Index: asterisk-18.1.1/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-18.1.1/rest-api/resources.json
+Index: asterisk-18.2.0/rest-api/resources.json
 ===================================================================
---- asterisk-18.1.1.orig/rest-api/resources.json
-+++ asterisk-18.1.1/rest-api/resources.json
+--- asterisk-18.2.0.orig/rest-api/resources.json
++++ asterisk-18.2.0/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1547,10 +1547,10 @@ Index: asterisk-18.1.1/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-18.1.1/include/asterisk/app.h
+Index: asterisk-18.2.0/include/asterisk/app.h
 ===================================================================
---- asterisk-18.1.1.orig/include/asterisk/app.h
-+++ asterisk-18.1.1/include/asterisk/app.h
+--- asterisk-18.2.0.orig/include/asterisk/app.h
++++ asterisk-18.2.0/include/asterisk/app.h
 @@ -533,6 +533,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1640,10 +1640,10 @@ Index: asterisk-18.1.1/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-18.1.1/main/app.c
+Index: asterisk-18.2.0/main/app.c
 ===================================================================
---- asterisk-18.1.1.orig/main/app.c
-+++ asterisk-18.1.1/main/app.c
+--- asterisk-18.2.0.orig/main/app.c
++++ asterisk-18.2.0/main/app.c
 @@ -809,6 +809,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1703,11 +1703,11 @@ Index: asterisk-18.1.1/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-18.1.1/apps/app_voicemail.c
+Index: asterisk-18.2.0/apps/app_voicemail.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_voicemail.c
-+++ asterisk-18.1.1/apps/app_voicemail.c
-@@ -533,6 +533,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
+--- asterisk-18.2.0.orig/apps/app_voicemail.c
++++ asterisk-18.2.0/apps/app_voicemail.c
+@@ -537,6 +537,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
  
@@ -1718,7 +1718,7 @@ Index: asterisk-18.1.1/apps/app_voicemail.c
  #define MAX_DATETIME_FORMAT	512
  #define MAX_NUM_CID_CONTEXTS 10
  
-@@ -1059,6 +1063,13 @@ static int vm_msg_forward(const char *fr
+@@ -1065,6 +1069,13 @@ static int vm_msg_forward(const char *fr
  static int vm_msg_move(const char *mailbox, const char *context, size_t num_msgs, const char *oldfolder, const char *old_msg_ids[], const char *newfolder);
  static int vm_msg_remove(const char *mailbox, const char *context, size_t num_msgs, const char *folder, const char *msgs[]);
  static int vm_msg_play(struct ast_channel *chan, const char *mailbox, const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb cb);
@@ -1732,7 +1732,7 @@ Index: asterisk-18.1.1/apps/app_voicemail.c
  
  #ifdef TEST_FRAMEWORK
  static int vm_test_destroy_user(const char *context, const char *mailbox);
-@@ -5724,6 +5735,8 @@ static int invent_message(struct ast_cha
+@@ -5738,6 +5749,8 @@ static int invent_message(struct ast_cha
  		return -1;
  	}
  
@@ -1741,7 +1741,7 @@ Index: asterisk-18.1.1/apps/app_voicemail.c
  	RETRIEVE(fn, -1, ext, context);
  	if (ast_fileexists(fn, NULL, NULL) > 0) {
  		res = ast_stream_and_wait(chan, fn, ecodes);
-@@ -14993,6 +15006,10 @@ static const struct ast_vm_functions vm_
+@@ -15015,6 +15028,10 @@ static const struct ast_vm_functions vm_
  	.msg_remove = vm_msg_remove,
  	.msg_forward = vm_msg_forward,
  	.msg_play = vm_msg_play,
@@ -1752,7 +1752,7 @@ Index: asterisk-18.1.1/apps/app_voicemail.c
  };
  
  static const struct ast_vm_greeter_functions vm_greeter_table = {
-@@ -16557,6 +16574,191 @@ play2_msg_cleanup:
+@@ -16579,6 +16596,191 @@ play2_msg_cleanup:
  	return res;
  }
  
@@ -1944,10 +1944,10 @@ Index: asterisk-18.1.1/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-18.1.1/main/http.c
+Index: asterisk-18.2.0/main/http.c
 ===================================================================
---- asterisk-18.1.1.orig/main/http.c
-+++ asterisk-18.1.1/main/http.c
+--- asterisk-18.2.0.orig/main/http.c
++++ asterisk-18.2.0/main/http.c
 @@ -82,7 +82,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */

--- a/debian/patches/wazo_banner
+++ b/debian/patches/wazo_banner
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/main/asterisk.c
+Index: asterisk-18.2.0/main/asterisk.c
 ===================================================================
---- asterisk-18.1.1.orig/main/asterisk.c
-+++ asterisk-18.1.1/main/asterisk.c
+--- asterisk-18.2.0.orig/main/asterisk.c
++++ asterisk-18.2.0/main/asterisk.c
 @@ -307,6 +307,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \

--- a/debian/patches/wazo_bridge_variables
+++ b/debian/patches/wazo_bridge_variables
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/include/asterisk/bridge.h
+Index: asterisk-18.2.0/include/asterisk/bridge.h
 ===================================================================
---- asterisk-18.1.1.orig/include/asterisk/bridge.h
-+++ asterisk-18.1.1/include/asterisk/bridge.h
+--- asterisk-18.2.0.orig/include/asterisk/bridge.h
++++ asterisk-18.2.0/include/asterisk/bridge.h
 @@ -257,6 +257,31 @@ typedef void (*ast_bridge_notify_masquer
  typedef int (*ast_bridge_merge_priority_fn)(struct ast_bridge *self);
  
@@ -85,10 +85,10 @@ Index: asterisk-18.1.1/include/asterisk/bridge.h
  #if defined(__cplusplus) || defined(c_plusplus)
  }
  #endif
-Index: asterisk-18.1.1/main/bridge.c
+Index: asterisk-18.2.0/main/bridge.c
 ===================================================================
---- asterisk-18.1.1.orig/main/bridge.c
-+++ asterisk-18.1.1/main/bridge.c
+--- asterisk-18.2.0.orig/main/bridge.c
++++ asterisk-18.2.0/main/bridge.c
 @@ -118,6 +118,8 @@
  #include "asterisk/core_local.h"
  #include "asterisk/core_unreal.h"
@@ -151,10 +151,10 @@ Index: asterisk-18.1.1/main/bridge.c
  static int manager_bridge_tech_list(struct mansession *s, const struct message *m)
  {
  	const char *id = astman_get_header(m, "ActionID");
-Index: asterisk-18.1.1/res/ari/resource_bridges.c
+Index: asterisk-18.2.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-18.1.1.orig/res/ari/resource_bridges.c
-+++ asterisk-18.1.1/res/ari/resource_bridges.c
+--- asterisk-18.2.0.orig/res/ari/resource_bridges.c
++++ asterisk-18.2.0/res/ari/resource_bridges.c
 @@ -44,6 +44,10 @@
  #include "asterisk/file.h"
  #include "asterisk/musiconhold.h"
@@ -288,10 +288,10 @@ Index: asterisk-18.1.1/res/ari/resource_bridges.c
 +	ast_ari_response_ok(response, response->message);
 +}
 \ No newline at end of file
-Index: asterisk-18.1.1/res/ari/resource_bridges.h
+Index: asterisk-18.2.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-18.1.1.orig/res/ari/resource_bridges.h
-+++ asterisk-18.1.1/res/ari/resource_bridges.h
+--- asterisk-18.2.0.orig/res/ari/resource_bridges.h
++++ asterisk-18.2.0/res/ari/resource_bridges.h
 @@ -395,5 +395,59 @@ int ast_ari_bridges_record_parse_body(
   * \param[out] response HTTP response
   */
@@ -352,10 +352,10 @@ Index: asterisk-18.1.1/res/ari/resource_bridges.h
 +void ast_ari_bridges_set_bridge_var(struct ast_variable *headers, struct ast_ari_bridges_set_bridge_var_args *args, struct ast_ari_response *response);
  
  #endif /* _ASTERISK_RESOURCE_BRIDGES_H */
-Index: asterisk-18.1.1/res/res_ari_bridges.c
+Index: asterisk-18.2.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-18.1.1.orig/res/res_ari_bridges.c
-+++ asterisk-18.1.1/res/res_ari_bridges.c
+--- asterisk-18.2.0.orig/res/res_ari_bridges.c
++++ asterisk-18.2.0/res/res_ari_bridges.c
 @@ -1461,6 +1461,179 @@ static void ast_ari_bridges_record_cb(
  fin: __attribute__((unused))
  	return;
@@ -564,10 +564,10 @@ Index: asterisk-18.1.1/res/res_ari_bridges.c
  };
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges = {
-Index: asterisk-18.1.1/rest-api/api-docs/bridges.json
+Index: asterisk-18.2.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-18.1.1.orig/rest-api/api-docs/bridges.json
-+++ asterisk-18.1.1/rest-api/api-docs/bridges.json
+--- asterisk-18.2.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-18.2.0/rest-api/api-docs/bridges.json
 @@ -574,7 +574,6 @@
  							"reason": "Bridge not in a Stasis application"
  						}
@@ -685,10 +685,10 @@ Index: asterisk-18.1.1/rest-api/api-docs/bridges.json
  				}
  			}
  		}
-Index: asterisk-18.1.1/include/asterisk/stasis_bridges.h
+Index: asterisk-18.2.0/include/asterisk/stasis_bridges.h
 ===================================================================
---- asterisk-18.1.1.orig/include/asterisk/stasis_bridges.h
-+++ asterisk-18.1.1/include/asterisk/stasis_bridges.h
+--- asterisk-18.2.0.orig/include/asterisk/stasis_bridges.h
++++ asterisk-18.2.0/include/asterisk/stasis_bridges.h
 @@ -94,6 +94,9 @@ struct ast_bridge_merge_message {
  	struct ast_bridge_snapshot *to;		/*!< Bridge to which channels will be added during the merge */
  };
@@ -717,10 +717,10 @@ Index: asterisk-18.1.1/include/asterisk/stasis_bridges.h
   * \brief Blob of data associated with a bridge.
   *
   * The \c blob is actually a JSON object of structured data. It has a "type" field
-Index: asterisk-18.1.1/main/stasis_bridges.c
+Index: asterisk-18.2.0/main/stasis_bridges.c
 ===================================================================
---- asterisk-18.1.1.orig/main/stasis_bridges.c
-+++ asterisk-18.1.1/main/stasis_bridges.c
+--- asterisk-18.2.0.orig/main/stasis_bridges.c
++++ asterisk-18.2.0/main/stasis_bridges.c
 @@ -37,6 +37,7 @@
  #include "asterisk/stasis_channels.h"
  #include "asterisk/bridge.h"
@@ -861,10 +861,10 @@ Index: asterisk-18.1.1/main/stasis_bridges.c
  
  	return res;
  }
-Index: asterisk-18.1.1/rest-api/api-docs/events.json
+Index: asterisk-18.2.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-18.1.1.orig/rest-api/api-docs/events.json
-+++ asterisk-18.1.1/rest-api/api-docs/events.json
+--- asterisk-18.2.0.orig/rest-api/api-docs/events.json
++++ asterisk-18.2.0/rest-api/api-docs/events.json
 @@ -162,6 +162,7 @@
  				"ApplicationMoveFailed",
  				"ApplicationReplaced",

--- a/debian/patches/wazo_mixmonitor_events
+++ b/debian/patches/wazo_mixmonitor_events
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/apps/app_mixmonitor.c
+Index: asterisk-18.2.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_mixmonitor.c
-+++ asterisk-18.1.1/apps/app_mixmonitor.c
+--- asterisk-18.2.0.orig/apps/app_mixmonitor.c
++++ asterisk-18.2.0/apps/app_mixmonitor.c
 @@ -51,6 +51,8 @@
  #include "asterisk/channel.h"
  #include "asterisk/autochan.h"
@@ -11,57 +11,7 @@ Index: asterisk-18.1.1/apps/app_mixmonitor.c
  #include "asterisk/callerid.h"
  #include "asterisk/mod_format.h"
  #include "asterisk/linkedlists.h"
-@@ -865,6 +867,24 @@ static int setup_mixmonitor_ds(struct mi
- 	return 0;
- }
- 
-+static void mixmonitor_ds_remove_and_free(struct ast_channel *chan, const char *datastore_id)
-+{
-+	struct ast_datastore *datastore;
-+
-+	ast_channel_lock(chan);
-+
-+	datastore = ast_channel_datastore_find(chan, &mixmonitor_ds_info, datastore_id);
-+
-+	/*
-+	 * Currently the one place this function is called from guarantees a
-+	 * datastore is present, thus return checks can be avoided here.
-+	 */
-+	ast_channel_datastore_remove(chan, datastore);
-+	ast_datastore_free(datastore);
-+
-+	ast_channel_unlock(chan);
-+}
-+
- static int launch_monitor_thread(struct ast_channel *chan, const char *filename,
- 				  unsigned int flags, int readvol, int writevol,
- 				  const char *post_process, const char *filename_write,
-@@ -940,7 +960,6 @@ static int launch_monitor_thread(struct
- 			pbx_builtin_setvar_helper(chan, uid_channel_var, datastore_id);
- 		}
- 	}
--	ast_free(datastore_id);
- 
- 	mixmonitor->name = ast_strdup(ast_channel_name(chan));
- 
-@@ -990,12 +1009,16 @@ static int launch_monitor_thread(struct
- 	if (startmon(chan, &mixmonitor->audiohook)) {
- 		ast_log(LOG_WARNING, "Unable to add '%s' spy to channel '%s'\n",
- 			mixmonitor_spy_type, ast_channel_name(chan));
-+		mixmonitor_ds_remove_and_free(chan, datastore_id);
-+		ast_free(datastore_id);
- 		ast_autochan_destroy(mixmonitor->autochan);
- 		ast_audiohook_destroy(&mixmonitor->audiohook);
- 		mixmonitor_free(mixmonitor);
- 		return -1;
- 	}
- 
-+	ast_free(datastore_id);
-+
- 	/* reference be released at mixmonitor destruction */
- 	mixmonitor->callid = ast_read_threadstorage_callid();
- 
-@@ -1056,6 +1079,7 @@ static int mixmonitor_exec(struct ast_ch
+@@ -1077,6 +1079,7 @@ static int mixmonitor_exec(struct ast_ch
  	struct ast_flags flags = { 0 };
  	char *recipients = NULL;
  	char *parse;
@@ -69,7 +19,7 @@ Index: asterisk-18.1.1/apps/app_mixmonitor.c
  	AST_DECLARE_APP_ARGS(args,
  		AST_APP_ARG(filename);
  		AST_APP_ARG(options);
-@@ -1176,6 +1200,13 @@ static int mixmonitor_exec(struct ast_ch
+@@ -1197,6 +1200,13 @@ static int mixmonitor_exec(struct ast_ch
  		ast_module_unref(ast_module_info->self);
  	}
  
@@ -83,7 +33,7 @@ Index: asterisk-18.1.1/apps/app_mixmonitor.c
  	return 0;
  }
  
-@@ -1185,6 +1216,7 @@ static int stop_mixmonitor_full(struct a
+@@ -1206,6 +1216,7 @@ static int stop_mixmonitor_full(struct a
  	char *parse = "";
  	struct mixmonitor_ds *mixmonitor_ds;
  	const char *beep_id = NULL;
@@ -91,7 +41,7 @@ Index: asterisk-18.1.1/apps/app_mixmonitor.c
  
  	AST_DECLARE_APP_ARGS(args,
  		AST_APP_ARG(mixmonid);
-@@ -1242,6 +1274,13 @@ static int stop_mixmonitor_full(struct a
+@@ -1263,6 +1274,13 @@ static int stop_mixmonitor_full(struct a
  		ast_beep_stop(chan, beep_id);
  	}
  
@@ -105,7 +55,7 @@ Index: asterisk-18.1.1/apps/app_mixmonitor.c
  	return 0;
  }
  
-@@ -1329,6 +1368,8 @@ static int manager_mute_mixmonitor(struc
+@@ -1350,6 +1368,8 @@ static int manager_mute_mixmonitor(struc
  	const char *direction = astman_get_header(m,"Direction");
  	int clearmute = 1;
  	enum ast_audiohook_flags flag;
@@ -114,7 +64,7 @@ Index: asterisk-18.1.1/apps/app_mixmonitor.c
  
  	if (ast_strlen_zero(direction)) {
  		astman_send_error(s, m, "No direction specified. Must be read, write or both");
-@@ -1370,6 +1411,17 @@ static int manager_mute_mixmonitor(struc
+@@ -1391,6 +1411,17 @@ static int manager_mute_mixmonitor(struc
  		return AMI_SUCCESS;
  	}
  
@@ -132,10 +82,10 @@ Index: asterisk-18.1.1/apps/app_mixmonitor.c
  	astman_append(s, "Response: Success\r\n");
  
  	if (!ast_strlen_zero(id)) {
-Index: asterisk-18.1.1/include/asterisk/stasis_channels.h
+Index: asterisk-18.2.0/include/asterisk/stasis_channels.h
 ===================================================================
---- asterisk-18.1.1.orig/include/asterisk/stasis_channels.h
-+++ asterisk-18.1.1/include/asterisk/stasis_channels.h
+--- asterisk-18.2.0.orig/include/asterisk/stasis_channels.h
++++ asterisk-18.2.0/include/asterisk/stasis_channels.h
 @@ -590,7 +590,31 @@ struct stasis_message_type *ast_channel_
  struct stasis_message_type *ast_channel_monitor_stop_type(void);
  
@@ -169,11 +119,11 @@ Index: asterisk-18.1.1/include/asterisk/stasis_channels.h
   * \brief Message type for agent login on a channel
   *
   * \retval A stasis message type
-Index: asterisk-18.1.1/main/manager_channels.c
+Index: asterisk-18.2.0/main/manager_channels.c
 ===================================================================
---- asterisk-18.1.1.orig/main/manager_channels.c
-+++ asterisk-18.1.1/main/manager_channels.c
-@@ -1104,6 +1104,53 @@ static void channel_monitor_stop_cb(void
+--- asterisk-18.2.0.orig/main/manager_channels.c
++++ asterisk-18.2.0/main/manager_channels.c
+@@ -1116,6 +1116,53 @@ static void channel_monitor_stop_cb(void
  	publish_basic_channel_event("MonitorStop", EVENT_FLAG_CALL, payload->snapshot);
  }
  
@@ -227,7 +177,7 @@ Index: asterisk-18.1.1/main/manager_channels.c
  static int dial_status_end(const char *dialstatus)
  {
  	return (strcmp(dialstatus, "RINGING") &&
-@@ -1308,6 +1355,15 @@ int manager_channels_init(void)
+@@ -1320,6 +1367,15 @@ int manager_channels_init(void)
  	ret |= stasis_message_router_add(message_router,
  		ast_channel_monitor_stop_type(), channel_monitor_stop_cb, NULL);
  
@@ -243,10 +193,10 @@ Index: asterisk-18.1.1/main/manager_channels.c
  	/* If somehow we failed to add any routes, just shut down the whole
  	 * thing and fail it.
  	 */
-Index: asterisk-18.1.1/main/stasis.c
+Index: asterisk-18.2.0/main/stasis.c
 ===================================================================
---- asterisk-18.1.1.orig/main/stasis.c
-+++ asterisk-18.1.1/main/stasis.c
+--- asterisk-18.2.0.orig/main/stasis.c
++++ asterisk-18.2.0/main/stasis.c
 @@ -130,6 +130,9 @@
  							<enum name="ast_channel_moh_stop_type" />
  							<enum name="ast_channel_monitor_start_type" />
@@ -257,10 +207,10 @@ Index: asterisk-18.1.1/main/stasis.c
  							<enum name="ast_channel_agent_login_type" />
  							<enum name="ast_channel_agent_logoff_type" />
  							<enum name="ast_channel_talking_start" />
-Index: asterisk-18.1.1/main/stasis_channels.c
+Index: asterisk-18.2.0/main/stasis_channels.c
 ===================================================================
---- asterisk-18.1.1.orig/main/stasis_channels.c
-+++ asterisk-18.1.1/main/stasis_channels.c
+--- asterisk-18.2.0.orig/main/stasis_channels.c
++++ asterisk-18.2.0/main/stasis_channels.c
 @@ -1651,6 +1651,9 @@ STASIS_MESSAGE_TYPE_DEFN(ast_channel_moh
  	);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_start_type);

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/res/res_pjsip/location.c
+Index: asterisk-18.2.0/res/res_pjsip/location.c
 ===================================================================
---- asterisk-18.1.1.orig/res/res_pjsip/location.c
-+++ asterisk-18.1.1/res/res_pjsip/location.c
+--- asterisk-18.2.0.orig/res/res_pjsip/location.c
++++ asterisk-18.2.0/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,10 +41,10 @@ Index: asterisk-18.1.1/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-18.1.1/res/res_pjsip_registrar.c
+Index: asterisk-18.2.0/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-18.1.1.orig/res/res_pjsip_registrar.c
-+++ asterisk-18.1.1/res/res_pjsip_registrar.c
+--- asterisk-18.2.0.orig/res/res_pjsip_registrar.c
++++ asterisk-18.2.0/res/res_pjsip_registrar.c
 @@ -758,6 +758,9 @@ static void register_aor_core(pjsip_rx_d
  
  		if (!contact) {
@@ -76,10 +76,10 @@ Index: asterisk-18.1.1/res/res_pjsip_registrar.c
  			if (!contact) {
  				ast_log(LOG_ERROR, "Unable to bind contact '%s' to AOR '%s'\n",
  					contact_uri, aor_name);
-Index: asterisk-18.1.1/include/asterisk/res_pjsip.h
+Index: asterisk-18.2.0/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-18.1.1.orig/include/asterisk/res_pjsip.h
-+++ asterisk-18.1.1/include/asterisk/res_pjsip.h
+--- asterisk-18.2.0.orig/include/asterisk/res_pjsip.h
++++ asterisk-18.2.0/include/asterisk/res_pjsip.h
 @@ -300,6 +300,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
@@ -98,10 +98,10 @@ Index: asterisk-18.1.1/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-18.1.1/res/res_pjsip.c
+Index: asterisk-18.2.0/res/res_pjsip.c
 ===================================================================
---- asterisk-18.1.1.orig/res/res_pjsip.c
-+++ asterisk-18.1.1/res/res_pjsip.c
+--- asterisk-18.2.0.orig/res/res_pjsip.c
++++ asterisk-18.2.0/res/res_pjsip.c
 @@ -1839,6 +1839,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/apps/app_queue.c
+Index: asterisk-18.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_queue.c
-+++ asterisk-18.1.1/apps/app_queue.c
+--- asterisk-18.2.0.orig/apps/app_queue.c
++++ asterisk-18.2.0/apps/app_queue.c
 @@ -2230,6 +2230,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/apps/app_queue.c
+Index: asterisk-18.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_queue.c
-+++ asterisk-18.1.1/apps/app_queue.c
+--- asterisk-18.2.0.orig/apps/app_queue.c
++++ asterisk-18.2.0/apps/app_queue.c
 @@ -6065,7 +6065,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/main/stasis_channels.c
+Index: asterisk-18.2.0/main/stasis_channels.c
 ===================================================================
---- asterisk-18.1.1.orig/main/stasis_channels.c
-+++ asterisk-18.1.1/main/stasis_channels.c
+--- asterisk-18.2.0.orig/main/stasis_channels.c
++++ asterisk-18.2.0/main/stasis_channels.c
 @@ -1573,6 +1573,47 @@ static struct ast_json *unhold_to_json(s
  		"channel", json_channel);
  }
@@ -65,10 +65,10 @@ Index: asterisk-18.1.1/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_agent_login_type,
-Index: asterisk-18.1.1/rest-api/api-docs/events.json
+Index: asterisk-18.2.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-18.1.1.orig/rest-api/api-docs/events.json
-+++ asterisk-18.1.1/rest-api/api-docs/events.json
+--- asterisk-18.2.0.orig/rest-api/api-docs/events.json
++++ asterisk-18.2.0/rest-api/api-docs/events.json
 @@ -189,7 +189,9 @@
  				"StasisStart",
  				"TextMessageReceived",

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/res/ari/resource_channels.c
+Index: asterisk-18.2.0/res/ari/resource_channels.c
 ===================================================================
---- asterisk-18.1.1.orig/res/ari/resource_channels.c
-+++ asterisk-18.1.1/res/ari/resource_channels.c
+--- asterisk-18.2.0.orig/res/ari/resource_channels.c
++++ asterisk-18.2.0/res/ari/resource_channels.c
 @@ -1553,6 +1553,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-18.1.1/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-18.1.1/res/ari/resource_channels.h
+Index: asterisk-18.2.0/res/ari/resource_channels.h
 ===================================================================
---- asterisk-18.1.1.orig/res/ari/resource_channels.h
-+++ asterisk-18.1.1/res/ari/resource_channels.h
+--- asterisk-18.2.0.orig/res/ari/resource_channels.h
++++ asterisk-18.2.0/res/ari/resource_channels.h
 @@ -693,6 +693,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *variable;
  	/*! The value to set the variable to */
@@ -37,10 +37,10 @@ Index: asterisk-18.1.1/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-18.1.1/res/res_ari_channels.c
+Index: asterisk-18.2.0/res/res_ari_channels.c
 ===================================================================
---- asterisk-18.1.1.orig/res/res_ari_channels.c
-+++ asterisk-18.1.1/res/res_ari_channels.c
+--- asterisk-18.2.0.orig/res/res_ari_channels.c
++++ asterisk-18.2.0/res/res_ari_channels.c
 @@ -2372,6 +2372,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->value = ast_json_string_get(field);
@@ -62,10 +62,10 @@ Index: asterisk-18.1.1/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-18.1.1/rest-api/api-docs/channels.json
+Index: asterisk-18.2.0/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-18.1.1.orig/rest-api/api-docs/channels.json
-+++ asterisk-18.1.1/rest-api/api-docs/channels.json
+--- asterisk-18.2.0.orig/rest-api/api-docs/channels.json
++++ asterisk-18.2.0/rest-api/api-docs/channels.json
 @@ -1478,6 +1478,15 @@
  							"required": false,
  							"allowMultiple": false,

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/main/ccss.c
+Index: asterisk-18.2.0/main/ccss.c
 ===================================================================
---- asterisk-18.1.1.orig/main/ccss.c
-+++ asterisk-18.1.1/main/ccss.c
+--- asterisk-18.2.0.orig/main/ccss.c
++++ asterisk-18.2.0/main/ccss.c
 @@ -2669,6 +2669,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/include/asterisk/channel.h
+Index: asterisk-18.2.0/include/asterisk/channel.h
 ===================================================================
---- asterisk-18.1.1.orig/include/asterisk/channel.h
-+++ asterisk-18.1.1/include/asterisk/channel.h
+--- asterisk-18.2.0.orig/include/asterisk/channel.h
++++ asterisk-18.2.0/include/asterisk/channel.h
 @@ -4567,6 +4567,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
@@ -21,10 +21,10 @@ Index: asterisk-18.1.1/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-18.1.1/main/channel.c
+Index: asterisk-18.2.0/main/channel.c
 ===================================================================
---- asterisk-18.1.1.orig/main/channel.c
-+++ asterisk-18.1.1/main/channel.c
+--- asterisk-18.2.0.orig/main/channel.c
++++ asterisk-18.2.0/main/channel.c
 @@ -11092,3 +11092,8 @@ void ast_channel_clear_flag(struct ast_c
  	ast_clear_flag(ast_channel_flags(chan), flag);
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/main/features.c
+Index: asterisk-18.2.0/main/features.c
 ===================================================================
---- asterisk-18.1.1.orig/main/features.c
-+++ asterisk-18.1.1/main/features.c
+--- asterisk-18.2.0.orig/main/features.c
++++ asterisk-18.2.0/main/features.c
 @@ -666,6 +666,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/include/asterisk/file.h
+Index: asterisk-18.2.0/include/asterisk/file.h
 ===================================================================
---- asterisk-18.1.1.orig/include/asterisk/file.h
-+++ asterisk-18.1.1/include/asterisk/file.h
+--- asterisk-18.2.0.orig/include/asterisk/file.h
++++ asterisk-18.2.0/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,10 +10,10 @@ Index: asterisk-18.1.1/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-18.1.1/main/bridge_basic.c
+Index: asterisk-18.2.0/main/bridge_basic.c
 ===================================================================
---- asterisk-18.1.1.orig/main/bridge_basic.c
-+++ asterisk-18.1.1/main/bridge_basic.c
+--- asterisk-18.2.0.orig/main/bridge_basic.c
++++ asterisk-18.2.0/main/bridge_basic.c
 @@ -3183,7 +3183,7 @@ static int grab_transfer(struct ast_chan
  	ast_channel_unlock(chan);
  

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,9 +1,9 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-18.1.1/apps/app_queue.c
+Index: asterisk-18.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_queue.c
-+++ asterisk-18.1.1/apps/app_queue.c
-@@ -9993,6 +9993,7 @@ static int manager_queues_summary(struct
+--- asterisk-18.2.0.orig/apps/app_queue.c
++++ asterisk-18.2.0/apps/app_queue.c
+@@ -10020,6 +10020,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;
  	int qmemcount = 0;
@@ -11,7 +11,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	int qmemavail = 0;
  	int qchancount = 0;
  	int qlongestholdtime = 0;
-@@ -10020,6 +10021,7 @@ static int manager_queues_summary(struct
+@@ -10047,6 +10048,7 @@ static int manager_queues_summary(struct
  		if (ast_strlen_zero(queuefilter) || !strcasecmp(q->name, queuefilter)) {
  			/* Reset the necessary local variables if no queuefilter is set*/
  			qmemcount = 0;
@@ -19,7 +19,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  			qmemavail = 0;
  			qchancount = 0;
  			qlongestholdtime = 0;
-@@ -10033,6 +10035,9 @@ static int manager_queues_summary(struct
+@@ -10060,6 +10062,9 @@ static int manager_queues_summary(struct
  						++qmemavail;
  					}
  				}
@@ -29,7 +29,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  				ao2_ref(mem, -1);
  			}
  			ao2_iterator_destroy(&mem_iter);
-@@ -10046,13 +10051,14 @@ static int manager_queues_summary(struct
+@@ -10073,13 +10078,14 @@ static int manager_queues_summary(struct
  				"Queue: %s\r\n"
  				"LoggedIn: %d\r\n"
  				"Available: %d\r\n"

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/apps/app_queue.c
+Index: asterisk-18.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_queue.c
-+++ asterisk-18.1.1/apps/app_queue.c
+--- asterisk-18.2.0.orig/apps/app_queue.c
++++ asterisk-18.2.0/apps/app_queue.c
 @@ -1573,6 +1573,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/apps/app_queue.c
+Index: asterisk-18.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_queue.c
-+++ asterisk-18.1.1/apps/app_queue.c
+--- asterisk-18.2.0.orig/apps/app_queue.c
++++ asterisk-18.2.0/apps/app_queue.c
 @@ -4276,7 +4276,7 @@ static int say_position(struct queue_ent
  		}
  

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/apps/app_queue.c
+Index: asterisk-18.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_queue.c
-+++ asterisk-18.1.1/apps/app_queue.c
+--- asterisk-18.2.0.orig/apps/app_queue.c
++++ asterisk-18.2.0/apps/app_queue.c
 @@ -6421,10 +6421,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/main/channel.c
+Index: asterisk-18.2.0/main/channel.c
 ===================================================================
---- asterisk-18.1.1.orig/main/channel.c
-+++ asterisk-18.1.1/main/channel.c
+--- asterisk-18.2.0.orig/main/channel.c
++++ asterisk-18.2.0/main/channel.c
 @@ -4877,7 +4877,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_sip_tel_uri
+++ b/debian/patches/xivo_sip_tel_uri
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/channels/sip/reqresp_parser.c
+Index: asterisk-18.2.0/channels/sip/reqresp_parser.c
 ===================================================================
---- asterisk-18.1.1.orig/channels/sip/reqresp_parser.c
-+++ asterisk-18.1.1/channels/sip/reqresp_parser.c
+--- asterisk-18.2.0.orig/channels/sip/reqresp_parser.c
++++ asterisk-18.2.0/channels/sip/reqresp_parser.c
 @@ -925,7 +925,7 @@ int get_name_and_number(const char *hdr,
  	tmp_number = get_in_brackets(header);
  

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,7 +1,7 @@
-Index: asterisk-18.1.1/apps/app_queue.c
+Index: asterisk-18.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-18.1.1.orig/apps/app_queue.c
-+++ asterisk-18.1.1/apps/app_queue.c
+--- asterisk-18.2.0.orig/apps/app_queue.c
++++ asterisk-18.2.0/apps/app_queue.c
 @@ -1400,6 +1400,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
@@ -842,49 +842,49 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	if (ast_test_flag(mask, QUEUE_RESET_STATS)) {
  		res |= clear_stats(queuename);
  	}
-@@ -9778,6 +10037,8 @@ static char *__queues_show(struct manses
- 						mem->status == AST_DEVICE_UNAVAILABLE || mem->status == AST_DEVICE_UNKNOWN ?
- 							COLOR_RED : COLOR_GREEN, COLOR_BLACK),
- 						ast_devstate2str(mem->status), ast_term_reset());
-+				if (!ast_strlen_zero(mem->skills))
-+					ast_str_append(&out, 0, " (skills: %s)", mem->skills);
- 				if (mem->calls) {
- 					ast_str_append(&out, 0, " has taken %d calls (last was %ld secs ago)",
- 						mem->calls, (long) (now - mem->lastcall));
-@@ -9795,8 +10056,32 @@ static char *__queues_show(struct manses
- 			struct queue_ent *qe;
- 			int pos = 1;
+@@ -9716,6 +9975,8 @@ static void print_queue(struct mansessio
+ 					mem->status == AST_DEVICE_UNAVAILABLE || mem->status == AST_DEVICE_UNKNOWN ?
+ 						COLOR_RED : COLOR_GREEN, COLOR_BLACK),
+ 					ast_devstate2str(mem->status), ast_term_reset());
++			if (!ast_strlen_zero(mem->skills))
++				ast_str_append(&out, 0, " (skills: %s)", mem->skills);
+ 			if (mem->calls) {
+ 				ast_str_append(&out, 0, " has taken %d calls (last was %ld secs ago)",
+ 					mem->calls, (long) (now - mem->lastcall));
+@@ -9733,8 +9994,32 @@ static void print_queue(struct mansessio
+ 		struct queue_ent *qe;
+ 		int pos = 1;
  
-+			if (q->vqueues) {
-+				struct virtual_queue *vqueue;
-+				struct ao2_iterator iter;
-+				iter = ao2_iterator_init(q->vqueues, 0);
-+				while ((vqueue = ao2_iterator_next(&iter)))
-+				{
-+					pos = 1;
-+					ast_str_set(&out, 0, "   Virtual queue %s: ", vqueue->id);
++		if (q->vqueues) {
++			struct virtual_queue *vqueue;
++			struct ao2_iterator iter;
++			iter = ao2_iterator_init(q->vqueues, 0);
++			while ((vqueue = ao2_iterator_next(&iter)))
++			{
++				pos = 1;
++				ast_str_set(&out, 0, "   Virtual queue %s: ", vqueue->id);
++				do_print(s, fd, ast_str_buffer(out));
++				for (qe = q->head; qe; qe = qe->next) {
++					if (qe->vqueue != vqueue)
++						continue;
++					ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
++						pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
++						(long) (now - qe->start) % 60, qe->prio);
 +					do_print(s, fd, ast_str_buffer(out));
-+					for (qe = q->head; qe; qe = qe->next) {
-+						if (qe->vqueue != vqueue)
-+							continue;
-+						ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
-+							pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
-+							(long) (now - qe->start) % 60, qe->prio);
-+						do_print(s, fd, ast_str_buffer(out));
-+					}
-+					ao2_ref(vqueue, -1);
 +				}
-+				ao2_iterator_destroy(&iter);
++				ao2_ref(vqueue, -1);
 +			}
++			ao2_iterator_destroy(&iter);
++		}
 +
- 			do_print(s, fd, "   Callers: ");
- 			for (qe = q->head; qe; qe = qe->next) {
-+				if (qe->vqueue)
-+					continue;
- 				ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
- 					pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
- 					(long) (now - qe->start) % 60, qe->prio);
-@@ -10144,11 +10429,12 @@ static int manager_queues_status(struct
+ 		do_print(s, fd, "   Callers: ");
+ 		for (qe = q->head; qe; qe = qe->next) {
++			if (qe->vqueue)
++				continue;
+ 			ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
+ 				pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
+ 				(long) (now - qe->start) % 60, qe->prio);
+@@ -10171,11 +10456,12 @@ static int manager_queues_status(struct
  						"Paused: %d\r\n"
  						"PausedReason: %s\r\n"
  						"Wrapuptime: %d\r\n"
@@ -898,7 +898,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  					++q_items;
  				}
  				ao2_ref(mem, -1);
-@@ -10193,7 +10479,7 @@ static int manager_queues_status(struct
+@@ -10220,7 +10506,7 @@ static int manager_queues_status(struct
  
  static int manager_add_queue_member(struct mansession *s, const struct message *m)
  {
@@ -907,7 +907,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	int paused, penalty, wrapuptime = 0;
  
  	queuename = astman_get_header(m, "Queue");
-@@ -10203,6 +10489,7 @@ static int manager_add_queue_member(stru
+@@ -10230,6 +10516,7 @@ static int manager_add_queue_member(stru
  	membername = astman_get_header(m, "MemberName");
  	state_interface = astman_get_header(m, "StateInterface");
  	wrapuptime_s = astman_get_header(m, "Wrapuptime");
@@ -915,7 +915,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  
  	if (ast_strlen_zero(queuename)) {
  		astman_send_error(s, m, "'Queue' not specified.");
-@@ -10232,7 +10519,7 @@ static int manager_add_queue_member(stru
+@@ -10259,7 +10546,7 @@ static int manager_add_queue_member(stru
  		paused = abs(ast_true(paused_s));
  	}
  
@@ -924,7 +924,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "MANAGER", interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -10363,6 +10650,14 @@ static int manager_queue_reload(struct m
+@@ -10390,6 +10677,14 @@ static int manager_queue_reload(struct m
  		ast_set_flag(&mask, QUEUE_RELOAD_RULES);
  		header_found = 1;
  	}
@@ -939,7 +939,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	if (!strcasecmp(S_OR(astman_get_header(m, "Parameters"), ""), "yes")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
  		header_found = 1;
-@@ -10532,7 +10827,7 @@ static int manager_change_priority_calle
+@@ -10559,7 +10854,7 @@ static int manager_change_priority_calle
  
  static char *handle_queue_add_member(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
  {
@@ -948,7 +948,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	int penalty;
  
  	switch ( cmd ) {
-@@ -10546,7 +10841,7 @@ static char *handle_queue_add_member(str
+@@ -10573,7 +10868,7 @@ static char *handle_queue_add_member(str
  		return complete_queue_add_member(a->line, a->word, a->pos, a->n);
  	}
  
@@ -957,7 +957,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  		return CLI_SHOWUSAGE;
  	} else if (strcmp(a->argv[4], "to")) {
  		return CLI_SHOWUSAGE;
-@@ -10556,6 +10851,8 @@ static char *handle_queue_add_member(str
+@@ -10583,6 +10878,8 @@ static char *handle_queue_add_member(str
  		return CLI_SHOWUSAGE;
  	} else if ((a->argc == 12) && strcmp(a->argv[10], "state_interface")) {
  		return CLI_SHOWUSAGE;
@@ -966,7 +966,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	}
  
  	queuename = a->argv[5];
-@@ -10582,7 +10879,11 @@ static char *handle_queue_add_member(str
+@@ -10609,7 +10906,11 @@ static char *handle_queue_add_member(str
  		state_interface = a->argv[11];
  	}
  
@@ -979,7 +979,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "CLI", interface, "ADDMEMBER", "%s", "");
-@@ -11107,6 +11408,10 @@ static char *handle_queue_reload(struct
+@@ -11134,6 +11435,10 @@ static char *handle_queue_reload(struct
  		ast_set_flag(&mask, QUEUE_RELOAD_MEMBER);
  	} else if (!strcasecmp(a->argv[2], "parameters")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
@@ -990,7 +990,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  	} else if (!strcasecmp(a->argv[2], "all")) {
  		ast_set_flag(&mask, AST_FLAGS_ALL);
  	}
-@@ -11203,6 +11508,1182 @@ static int qupd_exec(struct ast_channel
+@@ -11230,6 +11535,1182 @@ static int qupd_exec(struct ast_channel
  	return 0;
  }
  
@@ -2173,7 +2173,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  static struct ast_cli_entry cli_queue[] = {
  	AST_CLI_DEFINE(queue_show, "Show status of a specified queue"),
  	AST_CLI_DEFINE(handle_queue_rule_show, "Show the rules defined in queuerules.conf"),
-@@ -11214,11 +12695,10 @@ static struct ast_cli_entry cli_queue[]
+@@ -11241,11 +12722,10 @@ static struct ast_cli_entry cli_queue[]
  	AST_CLI_DEFINE(handle_queue_reload, "Reload queues, members, queue rules, or parameters"),
  	AST_CLI_DEFINE(handle_queue_reset, "Reset statistics for a queue"),
  	AST_CLI_DEFINE(handle_queue_change_priority_caller, "Change priority caller on queue"),
@@ -2187,7 +2187,7 @@ Index: asterisk-18.1.1/apps/app_queue.c
  static int unload_module(void)
  {
  	stasis_message_router_unsubscribe_and_join(agent_router);
-@@ -11442,31 +12922,6 @@ static int load_module(void)
+@@ -11469,31 +12949,6 @@ static int load_module(void)
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -2219,10 +2219,10 @@ Index: asterisk-18.1.1/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-18.1.1/configs/samples/queueskillrules.conf.sample
+Index: asterisk-18.2.0/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-18.1.1/configs/samples/queueskillrules.conf.sample
++++ asterisk-18.2.0/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2287,10 +2287,10 @@ Index: asterisk-18.1.1/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-18.1.1/configs/samples/queueskills.conf.sample
+Index: asterisk-18.2.0/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-18.1.1/configs/samples/queueskills.conf.sample
++++ asterisk-18.2.0/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
xivo_skill_queues: Indentation change in 2 hunks
wazo_mixmonitor_events: Remove code that was in the patch to match the 18 branch
when the patch got written that is unrelated

The version in this branch is suffixed by `~2` the version in asterisk-rc is `~1`. No fiddling has to be done when we are ready to merge.

Load tests launched on 2021-01-26 10:00:00 EST