### PR TITLE
Fix TTL zero stopping recurring STUN resolution

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:18.6.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Fix STUN DNS recurring resolution stopping on TTL = 0
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 27 Sep 2021 16:14:12 -0400
+
 asterisk (8:18.6.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Asterisk 18.6.0

--- a/debian/patches/wazo_stun_recurring_resolution
+++ b/debian/patches/wazo_stun_recurring_resolution
@@ -16,36 +16,52 @@ Index: asterisk-18.6.0/main/dns_recurring.c
 ===================================================================
 --- asterisk-18.6.0.orig/main/dns_recurring.c
 +++ asterisk-18.6.0/main/dns_recurring.c
-@@ -39,6 +39,11 @@
+@@ -39,6 +39,12 @@
  
  #include <arpa/nameser.h>
  
 +/* \brief Delay between TTL expiration and the next DNS query, to make sure the
 +resolver cache really expired. */
-+#define EXTRA_TTL 2
++#define DEFAULT_TTL 30
++#define EXTRA_TTL 1
 +#define MAX_TTL ((INT_MAX - EXTRA_TTL) / 1000)
 +
  /*! \brief Destructor for a DNS query */
  static void dns_query_recurring_destroy(void *data)
  {
-@@ -91,10 +96,10 @@ static void dns_query_recurring_resoluti
+@@ -91,14 +97,20 @@ static void dns_query_recurring_resoluti
  	/* So.. if something has not externally cancelled this we can reschedule based on the TTL */
  	if (!recurring->cancelled) {
  		const struct ast_dns_result *result = ast_dns_query_get_result(query);
 -		int ttl = MIN(ast_dns_result_get_lowest_ttl(result), INT_MAX / 1000);
-+		int ttl = MIN(ast_dns_result_get_lowest_ttl(result), MAX_TTL);
  
- 		if (ttl) {
+-		if (ttl) {
 -			recurring->timer = ast_sched_add(ast_dns_get_sched(), ttl * 1000, dns_query_recurring_scheduled_callback, ao2_bump(recurring));
-+			recurring->timer = ast_sched_add(ast_dns_get_sched(), (ttl + EXTRA_TTL) * 1000, dns_query_recurring_scheduled_callback, ao2_bump(recurring));
- 			if (recurring->timer < 0) {
- 				/* It is impossible for this to be the last reference as the query has a reference to it */
- 				ao2_ref(recurring, -1);
+-			if (recurring->timer < 0) {
+-				/* It is impossible for this to be the last reference as the query has a reference to it */
+-				ao2_ref(recurring, -1);
+-			}
++		int ttl = MIN(ast_dns_result_get_lowest_ttl(result), MAX_TTL);
++
++		/* If TTL is zero, DNS cache has expired. In which case set the next query to a sane
++		 * default value to avoid overloading the DNS server if TTL is always 0
++		 */
++		if (!ttl && (ttl = DEFAULT_TTL)) {
++			ast_debug(2, "TTL value of 0, forcing default value of %u", ttl);
++		}
++
++		recurring->timer = ast_sched_add(ast_dns_get_sched(), (ttl + EXTRA_TTL) * 1000, dns_query_recurring_scheduled_callback, ao2_bump(recurring));
++		if (recurring->timer < 0) {
++			/* It is impossible for this to be the last reference as the query has a reference to it */
++			ao2_ref(recurring, -1);
+ 		}
+ 	}
+ 
 Index: asterisk-18.6.0/res/res_rtp_asterisk.c
 ===================================================================
 --- asterisk-18.6.0.orig/res/res_rtp_asterisk.c
 +++ asterisk-18.6.0/res/res_rtp_asterisk.c
-@@ -36,6 +36,11 @@
+@@ -36,9 +36,15 @@
  
  #include "asterisk.h"
  
@@ -57,228 +73,296 @@ Index: asterisk-18.6.0/res/res_rtp_asterisk.c
  #include <sys/time.h>
  #include <signal.h>
  #include <fcntl.h>
-@@ -213,7 +218,7 @@ static int dtls_mtu = DEFAULT_DTLS_MTU;
++#include <math.h>
+ 
+ #ifdef HAVE_OPENSSL
+ #include <openssl/opensslconf.h>
+@@ -213,7 +219,7 @@ static int dtls_mtu = DEFAULT_DTLS_MTU;
  #ifdef HAVE_PJPROJECT
  static int icesupport = DEFAULT_ICESUPPORT;
  static int stun_software_attribute = DEFAULT_STUN_SOFTWARE_ATTRIBUTE;
 -static struct sockaddr_in stunaddr;
-+static struct ast_sockaddr stunaddr;
++static struct stun_resolver *stunres = NULL;
  static pj_str_t turnaddr;
  static int turnport = DEFAULT_TURN_PORT;
  static pj_str_t turnusername;
-@@ -229,6 +234,11 @@ static ast_rwlock_t ice_acl_lock = AST_R
- static struct ast_acl_list *stun_acl = NULL;
- static ast_rwlock_t stun_acl_lock = AST_RWLOCK_INIT_VALUE;
+@@ -273,6 +279,13 @@ struct ast_ice_host_candidate {
+ 	AST_RWLIST_ENTRY(ast_ice_host_candidate) next;
+ };
  
-+/*! stunaddr recurring resolution */
-+static ast_rwlock_t stunaddr_lock = AST_RWLOCK_INIT_VALUE;
-+static struct stunaddr_resolve_data *stunaddr_resolve_data;
-+static struct ast_dns_query_recurring *stunaddr_resolver = NULL;
++struct stun_resolver {
++	struct ast_sockaddr *address;
++	const char *hostname;
++	in_port_t port;
++	struct ast_dns_query_recurring *resolver;
++};
 +
- /*! \brief Pool factory used by pjlib to allocate memory. */
- static pj_caching_pool cachingpool;
+ /*! \brief List of ICE host candidate mappings */
+ static AST_RWLIST_HEAD_STATIC(host_candidates, ast_ice_host_candidate);
  
-@@ -645,6 +655,12 @@ static BIO_METHOD *dtls_bio_methods;
+@@ -645,6 +658,12 @@ static BIO_METHOD *dtls_bio_methods;
  
  static int __rtp_sendto(struct ast_rtp_instance *instance, void *buf, size_t size, int flags, struct ast_sockaddr *sa, int rtcp, int *via_ice, int use_srtp);
  
-+struct stunaddr_resolve_data {
-+	uint16_t port;
-+};
-+static void stunaddr_resolve_callback(const struct ast_dns_query *query);
-+static int store_stunaddr_resolved(const struct ast_dns_query *query);
++#ifdef HAVE_PJPROJECT
++static int stun_resolve(struct sockaddr_in *retaddr, const struct stun_resolver *stun);
++static struct stun_resolver *stun_resolve_create(const char *hostport);
++static void stun_resolve_stop(struct stun_resolver *stun);
++#endif
 +
  #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
  static int dtls_bio_new(BIO *bio)
  {
-@@ -3528,6 +3544,7 @@ static void rtp_add_candidates_to_ice(st
+@@ -3528,6 +3547,7 @@ static void rtp_add_candidates_to_ice(st
  	pj_sockaddr pjtmp;
  	struct ast_ice_host_candidate *candidate;
  	int af_inet_ok = 0, af_inet6_ok = 0;
-+	struct ast_sockaddr *stunaddr_pointer = NULL;
++	struct sockaddr_in stunaddr_copy;
  
  	if (ast_sockaddr_is_ipv4(addr)) {
  		af_inet_ok = 1;
-@@ -3637,12 +3654,17 @@ static void rtp_add_candidates_to_ice(st
+@@ -3637,8 +3657,10 @@ static void rtp_add_candidates_to_ice(st
  		freeifaddrs(ifa);
  	}
  
-+	ast_rwlock_rdlock(&stunaddr_lock);
-+	stunaddr_pointer = &stunaddr;
-+	ast_rwlock_unlock(&stunaddr_lock);
++	stun_resolve(&stunaddr_copy, stunres);
 +
  	/* If configured to use a STUN server to get our external mapped address do so */
 -	if (stunaddr.sin_addr.s_addr && !stun_address_is_blacklisted(addr) &&
-+	if (!ast_sockaddr_isnull(stunaddr_pointer) && !stun_address_is_blacklisted(addr) &&
++	if (stunaddr_copy.sin_addr.s_addr && !stun_address_is_blacklisted(addr) &&
  		(ast_sockaddr_is_ipv4(addr) || ast_sockaddr_is_any(addr)) &&
  		count < PJ_ICE_MAX_CAND) {
--		struct sockaddr_in answer;
-+		struct sockaddr_in answer, stun_sin;
- 		int rsp;
-+		ast_sockaddr_to_sin(stunaddr_pointer, &stun_sin);
- 
- 		ast_debug_category(3, AST_DEBUG_CATEGORY_ICE | AST_DEBUG_CATEGORY_STUN,
- 			"(%p) ICE request STUN %s %s candidate\n", instance,
+ 		struct sockaddr_in answer;
 @@ -3655,7 +3677,7 @@ static void rtp_add_candidates_to_ice(st
  		 */
  		ao2_unlock(instance);
  		rsp = ast_stun_request(component == AST_RTP_ICE_COMPONENT_RTCP
 -			? rtp->rtcp->s : rtp->s, &stunaddr, NULL, &answer);
-+			? rtp->rtcp->s : rtp->s, &stun_sin, NULL, &answer);
++			? rtp->rtcp->s : rtp->s, &stunaddr_copy, NULL, &answer);
  		ao2_lock(instance);
  		if (!rsp) {
  			struct ast_rtp_engine_ice_candidate *candidate;
-@@ -9008,6 +9030,87 @@ static int ast_rtp_bundle(struct ast_rtp
+@@ -9008,6 +9030,169 @@ static int ast_rtp_bundle(struct ast_rtp
  	return 0;
  }
  
-+static void stunaddr_resolve_callback(const struct ast_dns_query *query)
++#ifdef HAVE_PJPROJECT
++static void stun_resolve_destroy(void *obj)
 +{
-+	const int lowest_ttl = ast_dns_result_get_lowest_ttl(ast_dns_query_get_result(query));
-+	const char *stunaddr_name = ast_dns_query_get_name(query);
++	struct stun_resolver *stun = obj;
 +
-+	if (!store_stunaddr_resolved(query)) {
-+		ast_log(LOG_WARNING, "Failed to resolve stunaddr '%s'. Cancelling recurring resolution.\n", stunaddr_name);
-+		return;
++	if (stun->address) {
++		ast_sockaddr_setnull(stun->address);
++		ast_free(stun->address);
++		stun->address = NULL;
 +	}
-+
-+	ast_debug_stun(2, "Resolved stunaddr '%s' to '%s'. Lowest TTL = %d.\n",
-+		stunaddr_name,
-+		ast_sockaddr_stringify(&stunaddr),
-+		lowest_ttl);
-+
-+	if (!lowest_ttl) {
-+		ast_log(LOG_WARNING, "Resolution for stunaddr '%s' returned TTL = 0. Recurring resolution was cancelled.\n", ast_dns_query_get_name(query));
++	if (stun->hostname) {
++		ast_free((char *) stun->hostname);
++		stun->hostname = NULL;
 +	}
 +}
 +
-+static int store_stunaddr_resolved(const struct ast_dns_query *query)
++static void stun_resolve_callback(const struct ast_dns_query *query)
 +{
-+	const struct ast_dns_result *result = ast_dns_query_get_result(query);
-+	const struct ast_dns_record *record;
-+	const struct stunaddr_resolve_data *data = ast_dns_query_get_data(query);
-+	const in_port_t in_port = htons(data->port);
++	const char *data = NULL;
++	const char *hostname = NULL;
++	struct stun_resolver *stun = ast_dns_query_get_data(query);
++	struct ast_dns_result *result = ast_dns_query_get_result(query);
++	const struct ast_dns_record *record = ast_dns_result_get_records(result);
++	int ttl = ast_dns_result_get_lowest_ttl(result);
 +
-+	for (record = ast_dns_result_get_records(result); record; record = ast_dns_record_get_next(record)) {
-+		const size_t data_size = ast_dns_record_get_data_size(record);
-+		const unsigned char *data = (unsigned char *)ast_dns_record_get_data(record);
++	for (; record; record = ast_dns_record_get_next(record)) {
++		const size_t datasize = ast_dns_record_get_data_size(record);
 +		const int rr_type = ast_dns_record_get_rr_type(record);
++		data = ast_dns_record_get_data(record);
 +
-+		if (rr_type == ns_t_aaaa && data_size == 16) {
-+			struct sockaddr_in6 sin6 = { 0, };
++		switch (rr_type) {
++		case T_A:
++			if (datasize != 4) {
++				ast_debug_stun(2,
++							   "Retrieved an A record, but record size is invalid (size: %u, expected: %u)",
++							   (unsigned int) datasize,
++							   (unsigned int) 4);
++				continue;
++			}
++			ao2_lock(stun);
++			memcpy(&((struct sockaddr_in *) &(stun->address->ss))->sin_addr, data, datasize);
++			hostname = ast_strdupa(stun->hostname);
++			ao2_unlock(stun);
++			goto success;
 +
-+			sin6.sin6_port = in_port;
-+			memcpy(&sin6.sin6_addr, data, data_size);
-+			sin6.sin6_family = AF_INET6;
++		case T_AAAA:
++			ast_debug_stun(2, "Retrieved an AAAA record, but STUN implementation doesn't support IPv6.");
++			continue;
 +
-+			ast_rwlock_wrlock(&stunaddr_lock);
-+			memcpy(&stunaddr.ss, &sin6, sizeof(sin6));
-+			stunaddr.len = sizeof(sin6);
-+			ast_rwlock_unlock(&stunaddr_lock);
-+
-+			return 1;
-+		} else if (rr_type == ns_t_a && data_size == 4) {
-+			struct sockaddr_in sin4 = { 0, };
-+
-+			sin4.sin_port = in_port;
-+			memcpy(&sin4.sin_addr, data, data_size);
-+			sin4.sin_family = AF_INET;
-+
-+			ast_rwlock_wrlock(&stunaddr_lock);
-+			ast_sockaddr_from_sin(&stunaddr, &sin4);
-+			ast_rwlock_unlock(&stunaddr_lock);
-+
-+			return 1;
-+		} else {
-+			ast_debug_stun(3, "Unrecognized rr_type '%u' or data_size '%zu' from DNS query for stunaddr '%s'\n",
-+										 rr_type, data_size, ast_dns_query_get_name(query));
++		default:
++			ast_debug_stun(2, "Received invalid STUN address: '%s', moving to next entry...",
++						   ast_inet_ntoa(*(struct in_addr *) data));
 +			continue;
 +		}
 +	}
++	ast_debug_stun(2, "No valid entries found for STUN from DNS server.");
++	return;
++
++success:
++	ast_debug_stun(2,
++				   "Resolved STUN from DNS: '%s' -> '%s' (renews in %ds)",
++				   hostname,
++				   ast_inet_ntoa(*(struct in_addr *) data),
++				   ttl);
++}
++
++static int stun_resolve_init(struct stun_resolver *stun, const char *hostport)
++{
++	const char *szhostname = NULL;
++	const char *szport = NULL;
++	char *szinput = ast_strdupa(hostport);
++
++	if (!hostport || !stun || !szinput) {
++		return -1;
++	}
++
++	if (!ast_sockaddr_split_hostport((char *) szinput, (char **) &szhostname, (char **) &szport, 0)) {
++		ast_log(LOG_ERROR, "STUN address '%s' is using an invalid format, must use ipv4[:port] or host.name[:port] format", hostport);
++		return -1;
++	}
++	stun->hostname = ast_strdup(szhostname);
++	ast_parse_arg(szport, PARSE_UINT32 | PARSE_IN_RANGE | PARSE_DEFAULT, &stun->port, STANDARD_STUN_PORT, 1, 65535);
++
++	/* Check if it's an IPv4 address */
++	if (!ast_parse_arg(stun->hostname, PARSE_ADDR | PARSE_PORT_IGNORE, stun->address))
++	{
++		if (!ast_sockaddr_is_ipv4(stun->address)) {
++			ast_debug_stun(2, "STUN implementation doesn't support IPv6 addresses.");
++			return -1;
++		}
++		ast_sockaddr_set_port(stun->address, stun->port);
++		ast_debug_stun(2, "Resolving STUN using static address at '%s:%u'", stun->hostname, stun->port);
++	}
++	/* Else it's a canonical name that must be resolved */
++	else if (!ast_sockaddr_resolve_first_af(stun->address, stun->hostname, 0, AF_INET)) {
++		ast_sockaddr_set_port(stun->address, stun->port);
++		stun->resolver = ast_dns_resolve_recurring(stun->hostname, T_A, C_IN, stun_resolve_callback, stun);
++		if (!stun->resolver) {
++			ast_log(LOG_ERROR, "Failed to start recurring dns query");
++			return -1;
++		}
++		ast_debug_stun(2, "Initialized recurring DNS query to resolve STUN");
++	}
++	/* Not an IPv4 nor a CNAME */
++	else {
++		ast_log(LOG_ERROR, "Unable to parse STUN address: '%s'", hostport);
++		return -1;
++	}
++
 +	return 0;
 +}
 +
-+static void clean_stunaddr(void) {
-+	if (stunaddr_resolver) {
-+		if (ast_dns_resolve_recurring_cancel(stunaddr_resolver)) {
-+			ast_log(LOG_ERROR, "Failed to cancel recurring DNS resolution of previous stunaddr.\n");
-+		}
-+		ao2_ref(stunaddr_resolver, -1);
-+		stunaddr_resolver = NULL;
++static struct stun_resolver *stun_resolve_create(const char *hostport)
++{
++	struct stun_resolver *stun = NULL;
++
++	if (!(stun = ao2_alloc(sizeof(*stun), stun_resolve_destroy))) {
++		goto failure;
 +	}
-+	ao2_cleanup(stunaddr_resolve_data);
-+	stunaddr_resolve_data = NULL;
-+	ast_rwlock_wrlock(&stunaddr_lock);
-+	ast_sockaddr_setnull(&stunaddr);
-+	ast_rwlock_unlock(&stunaddr_lock);
++
++	if (!(stun->address = ast_calloc(1, sizeof(*stun->address)))) {
++		goto failure;
++	}
++
++	if (stun_resolve_init(stun, hostport)) {
++		goto failure;
++	}
++
++	return stun;
++
++failure:
++	ast_log(LOG_ERROR, "Failed to create STUN resolver.\n");
++	ao2_cleanup(stun);
++	return NULL;
 +}
++
++static void stun_resolve_stop(struct stun_resolver *stun)
++{
++	if (stun) {
++		if (stun->resolver) {
++			if (ast_dns_resolve_recurring_cancel(stun->resolver)) {
++				ast_log(LOG_ERROR, "Failed to stop STUN recurring resolver.\n");
++			}
++			ao2_cleanup(stun->resolver);
++			stun->resolver = NULL;
++		}
++		ao2_cleanup(stun);
++	}
++}
++
++static int stun_resolve(struct sockaddr_in *retsin, const struct stun_resolver *stun)
++{
++	if (!stun || !retsin) {
++		return -1;
++	}
++
++	ao2_lock((struct stun_resolver *) stun);
++	ast_sockaddr_to_sin(stun->address, retsin);
++	ao2_unlock((struct stun_resolver *) stun);
++	return 0;
++}
++#endif
 +
  #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
  /*! \pre instance is locked */
  static int ast_rtp_activate(struct ast_rtp_instance *instance)
-@@ -9137,6 +9240,7 @@ static char *handle_cli_rtp_settings(str
+@@ -9105,6 +9290,7 @@ static char *handle_cli_rtp_set_debug(st
+ 
+ static char *handle_cli_rtp_settings(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
+ {
++	struct sockaddr_in stunaddr_copy;
+ 	switch (cmd) {
+ 	case CLI_INIT:
+ 		e->command = "rtp show settings";
+@@ -9137,6 +9323,10 @@ static char *handle_cli_rtp_settings(str
  	ast_cli(a->fd, "  Replay Protect:  %s\n", AST_CLI_YESNO(srtp_replay_protection));
  #ifdef HAVE_PJPROJECT
  	ast_cli(a->fd, "  ICE support:     %s\n", AST_CLI_YESNO(icesupport));
-+	ast_cli(a->fd, "  STUN address:    %s\n", ast_sockaddr_stringify(&stunaddr));
++
++	if (!stun_resolve(&stunaddr_copy, stunres)) {
++		ast_cli(a->fd, "  STUN address:    %s:%d\n", ast_inet_ntoa(stunaddr_copy.sin_addr), htons(stunaddr_copy.sin_port));
++	}
  #endif
  	return CLI_SUCCESS;
  }
-@@ -9385,7 +9489,7 @@ static int rtp_reload(int reload, int by
+@@ -9385,11 +9575,11 @@ static int rtp_reload(int reload, int by
  	icesupport = DEFAULT_ICESUPPORT;
  	stun_software_attribute = DEFAULT_STUN_SOFTWARE_ATTRIBUTE;
  	turnport = DEFAULT_TURN_PORT;
 -	memset(&stunaddr, 0, sizeof(stunaddr));
-+	clean_stunaddr();
  	turnaddr = pj_str(NULL);
  	turnusername = pj_str(NULL);
  	turnpassword = pj_str(NULL);
-@@ -9463,9 +9567,37 @@ static int rtp_reload(int reload, int by
+ 	host_candidate_overrides_clear();
++	stun_resolve_stop(stunres);
+ #endif
+ 
+ #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
+@@ -9463,10 +9653,8 @@ static int rtp_reload(int reload, int by
  		stun_software_attribute = ast_true(s);
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "stunaddr"))) {
 -		stunaddr.sin_port = htons(STANDARD_STUN_PORT);
 -		if (ast_parse_arg(s, PARSE_INADDR, &stunaddr)) {
 -			ast_log(LOG_WARNING, "Invalid STUN server address: %s\n", s);
-+		char *hostport, *host, *port;
-+		unsigned int port_parsed = STANDARD_STUN_PORT;
-+		struct ast_sockaddr stunaddr_parsed;
-+
-+
-+		hostport = ast_strdupa(s);
-+
-+		if (!ast_parse_arg(hostport, PARSE_ADDR, &stunaddr_parsed)) {
-+			ast_debug_stun(3, "stunaddr = '%s' does not need name resolution\n", ast_sockaddr_stringify_host(&stunaddr_parsed));
-+			if (!ast_sockaddr_port(&stunaddr_parsed)) {
-+				ast_sockaddr_set_port(&stunaddr_parsed, STANDARD_STUN_PORT);
-+			}
-+			ast_rwlock_wrlock(&stunaddr_lock);
-+			ast_sockaddr_copy(&stunaddr, &stunaddr_parsed);
-+			ast_rwlock_unlock(&stunaddr_lock);
-+		} else if (ast_sockaddr_split_hostport(hostport, &host, &port, 0)) {
-+			if (port) {
-+				ast_parse_arg(port, PARSE_UINT32|PARSE_IN_RANGE, &port_parsed, 1, 65535);
-+			}
-+
-+			if (!(stunaddr_resolve_data = ao2_alloc(sizeof(*stunaddr_resolve_data), NULL))) {
-+				ast_log(LOG_ERROR, "Failed to allocate STUN resolution data.\n");
-+				return -1;
-+			}
-+			stunaddr_resolve_data->port = port_parsed;
-+			stunaddr_resolver = ast_dns_resolve_recurring(host, T_A, C_IN, &stunaddr_resolve_callback, stunaddr_resolve_data);
-+			if (!stunaddr_resolver) {
-+				ast_log(LOG_ERROR, "Failed to setup recurring DNS resolution of stunaddr '%s'", host);
-+			}
-+		} else {
-+			ast_log(LOG_ERROR, "Failed to parse stunaddr '%s'", hostport);
- 		}
+-		}
++		char *hostport = ast_strdupa(s);
++		stunres = stun_resolve_create(hostport);
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "turnaddr"))) {
-@@ -9725,6 +9857,7 @@ static int unload_module(void)
+ 		struct sockaddr_in addr;
+@@ -9725,6 +9913,8 @@ static int unload_module(void)
  	acl_change_sub = stasis_unsubscribe_and_join(acl_change_sub);
  	rtp_unload_acl(&ice_acl_lock, &ice_acl);
  	rtp_unload_acl(&stun_acl_lock, &stun_acl);
-+	clean_stunaddr();
++
++	stun_resolve_stop(stunres);
  #endif
  
  	return 0;


### PR DESCRIPTION
Why:

* If the TTL received from the DNS server is zero, meaning the
cache has expired, the recurring DNS would terminate itself.
With this fix, if a TTL of zero is received, a default value of
30 second is applied to the next query.

This 30 second delay avoids spamming the DNS server unnecessarily
if received TTL is always zero.

This change addresses the need by:

* If STUN server resolution stops, and the server is down, every
connection in Asterisk will timeout for 10 seconds while trying to
reach the STUN server, severely degrading user experience.
