### PR TITLE
res_rtp_asterisk: don't disable rtp_symmetric

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:18.6.0-1~wazo4) wazo-dev-buster; urgency=medium
+
+  * Test RTP symmetric enforcing
+
+ -- Wazo Maintainers <dev@wazo.community>  Fri, 29 Oct 2021 16:28:02 -0400
+
 asterisk (8:18.6.0-1~wazo3) wazo-dev-buster; urgency=medium
 
   * Fix STUN DNS recurring resolution stopping on TTL = 0

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,5 @@
 ### upstream fixes
+test-rtp-symmetric
 deb_astgenkey-security
 deb_make-clean-fixes
 ## Wazo patches

--- a/debian/patches/test-rtp-symmetric
+++ b/debian/patches/test-rtp-symmetric
@@ -1,0 +1,13 @@
+Index: asterisk-upstream/res/res_rtp_asterisk.c
+===================================================================
+--- asterisk-upstream.orig/res/res_rtp_asterisk.c
++++ asterisk-upstream/res/res_rtp_asterisk.c
+@@ -2607,7 +2607,7 @@ static void ast_rtp_ice_start_media(pj_i
+ 		update_address_with_ice_candidate(ice, AST_RTP_ICE_COMPONENT_RTP, &remote_address);
+ 		if (!ast_sockaddr_isnull(&remote_address)) {
+ 			/* Symmetric RTP must be disabled for the remote address to not get overwritten */
+-			ast_rtp_instance_set_prop(instance, AST_RTP_PROPERTY_NAT, 0);
++			/* ast_rtp_instance_set_prop(instance, AST_RTP_PROPERTY_NAT, 0); */
+ 
+ 			ast_rtp_instance_set_remote_address(instance, &remote_address);
+ 		}


### PR DESCRIPTION
Why:

* Maybe causing white comms after reinvites