### PR TITLE
WAZO-2646 Add null check for stun->address

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:18.8.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Add null check for STUN address
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 04 Jan 2022 09:34:33 -0500
+
 asterisk (8:18.8.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Asterisk 18.8.0
@@ -138,7 +144,7 @@ asterisk (8:17.7.0-1~wazo2) wazo-dev-buster; urgency=medium
 
 asterisk (8:17.6.0-1~wazo3) wazo-dev-buster; urgency=medium
 
-  * Fix logrotate command 
+  * Fix logrotate command
 
  -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 30 Sep 2020 13:54:56 -0400
 
@@ -606,7 +612,7 @@ asterisk (8:15.4.1-1~wazo1) wazo-dev-stretch; urgency=medium
 
 asterisk (8:15.4.0-1~wazo2) wazo-dev-stretch; urgency=medium
 
-  * Fix unit masking when using asterisk-vanilla 
+  * Fix unit masking when using asterisk-vanilla
 
  -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 15 May 2018 10:59:51 -0400
 
@@ -660,7 +666,7 @@ asterisk (8:15.1.3-1~wazo10) wazo-dev; urgency=medium
 
 asterisk (8:15.1.3-1~wazo9) wazo-dev; urgency=medium
 
-  * bump version 
+  * bump version
 
  -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 26 Dec 2017 14:53:09 -0500
 
@@ -1339,7 +1345,7 @@ asterisk11 (11.2.1+pf.xivo.13.05~20130312.141540.ebe5465-2) squeeze-xivo-skaro-d
 
 asterisk11 (11.1.2+pf.xivo.13.04~20130107.150857.298cca9-7) squeeze-xivo-skaro-dev; urgency=low
 
-  * fix typo 
+  * fix typo
 
  -- Nicolas HICHER <nhicher@avencall.com>  Mon, 25 Feb 2013 10:32:26 -0500
 
@@ -1352,13 +1358,13 @@ asterisk11 (11.1.2+pf.xivo.13.04~20130107.150857.298cca9-6) squeeze-xivo-skaro-d
 
 asterisk11 (11.1.2+pf.xivo.13.04~20130107.150857.298cca9-5) squeeze-xivo-skaro-dev; urgency=low
 
-  * revert init script 
+  * revert init script
 
  -- Nicolas HICHER <nhicher@avencall.com>  Sat, 23 Feb 2013 08:49:59 -0500
 
 asterisk11 (11.1.2+pf.xivo.13.04~20130107.150857.298cca9-3) squeeze-xivo-skaro-dev; urgency=low
 
-  * add provides, replaces, conflicts with asterisk 
+  * add provides, replaces, conflicts with asterisk
 
  -- Nicolas HICHER <nhicher@avencall.com>  Fri, 22 Feb 2013 14:40:04 -0500
 
@@ -1370,6 +1376,6 @@ asterisk11 (11.1.2+pf.xivo.13.04~20130107.150857.298cca9-2) squeeze-xivo-skaro-d
 
 asterisk11 (11.0.0-0) squeeze-xivo-skaro-dev; urgency=low
 
-  * asterisk 11 
+  * asterisk 11
 
  -- Nicolas HICHER (atarakt) <nhicher@proformatique.com>  Fri, 26 Oct 2012 15:19:17 -0400

--- a/debian/patches/wazo_stun_recurring_resolution
+++ b/debian/patches/wazo_stun_recurring_resolution
@@ -89,6 +89,15 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  #endif
  
  #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
+@@ -3543,7 +3550,7 @@ static void rtp_add_candidates_to_ice(st
+ 	pj_sockaddr pjtmp;
+ 	struct ast_ice_host_candidate *candidate;
+ 	int af_inet_ok = 0, af_inet6_ok = 0;
+-	struct sockaddr_in stunaddr_copy;
++	struct sockaddr_in stunaddr_copy = {0};
+ 
+ 	if (ast_sockaddr_is_ipv4(addr)) {
+ 		af_inet_ok = 1;
 @@ -3653,9 +3660,7 @@ static void rtp_add_candidates_to_ice(st
  		freeifaddrs(ifa);
  	}
@@ -100,7 +109,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  
  	/* If configured to use a STUN server to get our external mapped address do so */
  	if (stunaddr_copy.sin_addr.s_addr && !stun_address_is_blacklisted(addr) &&
-@@ -9034,70 +9039,171 @@ static int ast_rtp_bundle(struct ast_rtp
+@@ -9034,70 +9039,175 @@ static int ast_rtp_bundle(struct ast_rtp
  }
  
  #ifdef HAVE_PJPROJECT
@@ -312,13 +321,17 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
 +	}
 +
 +	ao2_rdlock((struct stun_resolver *) stun);
++	if (!stun->address) {
++		ao2_unlock((struct stun_resolver *) stun);
++		return -1;
++	}
 +	memcpy(retsin, stun->address, sizeof(*stun->address));
 +	ao2_unlock((struct stun_resolver *) stun);
 +	return 0;
  }
  #endif
  
-@@ -9234,10 +9340,9 @@ static char *handle_cli_rtp_settings(str
+@@ -9234,10 +9344,9 @@ static char *handle_cli_rtp_settings(str
  #ifdef HAVE_PJPROJECT
  	ast_cli(a->fd, "  ICE support:     %s\n", AST_CLI_YESNO(icesupport));
  
@@ -332,7 +345,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  #endif
  	return CLI_SUCCESS;
  }
-@@ -9486,7 +9591,7 @@ static int rtp_reload(int reload, int by
+@@ -9486,7 +9595,7 @@ static int rtp_reload(int reload, int by
  	icesupport = DEFAULT_ICESUPPORT;
  	stun_software_attribute = DEFAULT_STUN_SOFTWARE_ATTRIBUTE;
  	turnport = DEFAULT_TURN_PORT;
@@ -341,7 +354,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  	turnaddr = pj_str(NULL);
  	turnusername = pj_str(NULL);
  	turnpassword = pj_str(NULL);
-@@ -9564,36 +9669,8 @@ static int rtp_reload(int reload, int by
+@@ -9564,36 +9673,8 @@ static int rtp_reload(int reload, int by
  		stun_software_attribute = ast_true(s);
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "stunaddr"))) {
@@ -380,7 +393,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "turnaddr"))) {
  		struct sockaddr_in addr;
-@@ -9852,7 +9929,7 @@ static int unload_module(void)
+@@ -9852,7 +9933,7 @@ static int unload_module(void)
  	acl_change_sub = stasis_unsubscribe_and_join(acl_change_sub);
  	rtp_unload_acl(&ice_acl_lock, &ice_acl);
  	rtp_unload_acl(&stun_acl_lock, &stun_acl);

--- a/debian/patches/wazo_stun_recurring_resolution
+++ b/debian/patches/wazo_stun_recurring_resolution
@@ -64,7 +64,18 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  static pj_str_t turnaddr;
  static int turnport = DEFAULT_TURN_PORT;
  static pj_str_t turnusername;
-@@ -283,6 +283,12 @@ struct ast_ice_host_candidate {
+@@ -235,10 +235,6 @@ static ast_rwlock_t ice_acl_lock = AST_R
+ static struct ast_acl_list *stun_acl = NULL;
+ static ast_rwlock_t stun_acl_lock = AST_RWLOCK_INIT_VALUE;
+ 
+-/*! stunaddr recurring resolution */
+-static ast_rwlock_t stunaddr_lock = AST_RWLOCK_INIT_VALUE;
+-static struct ast_dns_query_recurring *stunaddr_resolver = NULL;
+-
+ /*! \brief Pool factory used by pjlib to allocate memory. */
+ static pj_caching_pool cachingpool;
+ 
+@@ -283,6 +279,12 @@ struct ast_ice_host_candidate {
  	AST_RWLIST_ENTRY(ast_ice_host_candidate) next;
  };
  
@@ -77,19 +88,19 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  /*! \brief List of ICE host candidate mappings */
  static AST_RWLIST_HEAD_STATIC(host_candidates, ast_ice_host_candidate);
  
-@@ -656,8 +662,9 @@ static BIO_METHOD *dtls_bio_methods;
+@@ -656,8 +658,9 @@ static BIO_METHOD *dtls_bio_methods;
  static int __rtp_sendto(struct ast_rtp_instance *instance, void *buf, size_t size, int flags, struct ast_sockaddr *sa, int rtcp, int *via_ice, int use_srtp);
  
  #ifdef HAVE_PJPROJECT
 -static void stunaddr_resolve_callback(const struct ast_dns_query *query);
 -static int store_stunaddr_resolved(const struct ast_dns_query *query);
-+static int stun_resolver_get_resolved(struct sockaddr_in *retaddr, const struct stun_resolver *stun);
++static int stun_resolver_get_resolved(struct sockaddr_in *retaddr, struct stun_resolver *stun);
 +static struct stun_resolver *stun_resolver_create(const char *hostport);
 +static void stun_resolver_stop(struct stun_resolver *stun);
  #endif
  
  #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
-@@ -3543,7 +3550,7 @@ static void rtp_add_candidates_to_ice(st
+@@ -3543,7 +3546,7 @@ static void rtp_add_candidates_to_ice(st
  	pj_sockaddr pjtmp;
  	struct ast_ice_host_candidate *candidate;
  	int af_inet_ok = 0, af_inet6_ok = 0;
@@ -98,7 +109,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  
  	if (ast_sockaddr_is_ipv4(addr)) {
  		af_inet_ok = 1;
-@@ -3653,9 +3660,7 @@ static void rtp_add_candidates_to_ice(st
+@@ -3653,9 +3656,7 @@ static void rtp_add_candidates_to_ice(st
  		freeifaddrs(ifa);
  	}
  
@@ -109,7 +120,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  
  	/* If configured to use a STUN server to get our external mapped address do so */
  	if (stunaddr_copy.sin_addr.s_addr && !stun_address_is_blacklisted(addr) &&
-@@ -9034,70 +9039,175 @@ static int ast_rtp_bundle(struct ast_rtp
+@@ -9034,70 +9035,175 @@ static int ast_rtp_bundle(struct ast_rtp
  }
  
  #ifdef HAVE_PJPROJECT
@@ -128,12 +139,12 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
 +		memset(stun->address, 0, sizeof(*stun->address));
 +		ast_free(stun->address);
 +		stun->address = NULL;
-+	}
+ 	}
 +	if (stun->hostname) {
 +		*(char *) stun->hostname = '\0';
 +		ast_free((char *) stun->hostname);
 +		stun->hostname = NULL;
- 	}
++	}
 +}
  
 -	if (DEBUG_ATLEAST(2)) {
@@ -158,9 +169,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
 +		const size_t datasize = ast_dns_record_get_data_size(record);
 +		const int rr_type = ast_dns_record_get_rr_type(record);
 +		data = ast_dns_record_get_data(record);
- 
--	if (!lowest_ttl) {
--		ast_log(LOG_WARNING, "Resolution for stunaddr '%s' returned TTL = 0. Recurring resolution was cancelled.\n", ast_dns_query_get_name(query));
++
 +		switch (rr_type) {
 +		case T_A:
 +			if (datasize != 4) {
@@ -184,7 +193,9 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
 +		case T_AAAA:
 +			ast_debug_stun(2, "Retrieved an AAAA record, but STUN implementation doesn't support IPv6.");
 +			continue;
-+
+ 
+-	if (!lowest_ttl) {
+-		ast_log(LOG_WARNING, "Resolution for stunaddr '%s' returned TTL = 0. Recurring resolution was cancelled.\n", ast_dns_query_get_name(query));
 +		default:
 +			ast_debug_stun(2, "Received invalid STUN address: '%s', moving to next entry...",
 +						   ast_inet_ntoa(*(struct in_addr *) data));
@@ -238,7 +249,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
 +		if (!ast_sockaddr_is_ipv4(&address)) {
 +			ast_debug_stun(2, "STUN implementation doesn't support IPv6 addresses.");
 +			return -1;
- 		}
++		}
 +		ast_sockaddr_set_port(&address, stunport);
 +		ast_sockaddr_to_sin(&address, stun->address);
 +		ast_debug_stun(2, "Resolving STUN using static address at '%s:%u'", stun->hostname, stunport);
@@ -251,7 +262,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
 +		if (!stun->resolver) {
 +			ast_log(LOG_ERROR, "Failed to start recurring dns query");
 +			return -1;
-+		}
+ 		}
 +		ast_debug_stun(2, "Initialized recurring DNS query to resolve STUN");
 +	}
 +	/* Not an IPv4 nor a canonical name */
@@ -314,24 +325,24 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
 +	ao2_cleanup(stun);
 +}
 +
-+static int stun_resolver_get_resolved(struct sockaddr_in *retsin, const struct stun_resolver *stun)
++static int stun_resolver_get_resolved(struct sockaddr_in *retsin, struct stun_resolver *stun)
 +{
 +	if (!stun || !retsin) {
 +		return -1;
 +	}
 +
-+	ao2_rdlock((struct stun_resolver *) stun);
++	ao2_rdlock(stun);
 +	if (!stun->address) {
-+		ao2_unlock((struct stun_resolver *) stun);
++		ao2_unlock(stun);
 +		return -1;
 +	}
 +	memcpy(retsin, stun->address, sizeof(*stun->address));
-+	ao2_unlock((struct stun_resolver *) stun);
++	ao2_unlock(stun);
 +	return 0;
  }
  #endif
  
-@@ -9234,10 +9344,9 @@ static char *handle_cli_rtp_settings(str
+@@ -9234,10 +9340,9 @@ static char *handle_cli_rtp_settings(str
  #ifdef HAVE_PJPROJECT
  	ast_cli(a->fd, "  ICE support:     %s\n", AST_CLI_YESNO(icesupport));
  
@@ -345,7 +356,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  #endif
  	return CLI_SUCCESS;
  }
-@@ -9486,7 +9595,7 @@ static int rtp_reload(int reload, int by
+@@ -9486,7 +9591,7 @@ static int rtp_reload(int reload, int by
  	icesupport = DEFAULT_ICESUPPORT;
  	stun_software_attribute = DEFAULT_STUN_SOFTWARE_ATTRIBUTE;
  	turnport = DEFAULT_TURN_PORT;
@@ -354,7 +365,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  	turnaddr = pj_str(NULL);
  	turnusername = pj_str(NULL);
  	turnpassword = pj_str(NULL);
-@@ -9564,36 +9673,8 @@ static int rtp_reload(int reload, int by
+@@ -9564,36 +9669,8 @@ static int rtp_reload(int reload, int by
  		stun_software_attribute = ast_true(s);
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "stunaddr"))) {
@@ -393,7 +404,7 @@ Index: asterisk-18.8.0/res/res_rtp_asterisk.c
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "turnaddr"))) {
  		struct sockaddr_in addr;
-@@ -9852,7 +9933,7 @@ static int unload_module(void)
+@@ -9852,7 +9929,7 @@ static int unload_module(void)
  	acl_change_sub = stasis_unsubscribe_and_join(acl_change_sub);
  	rtp_unload_acl(&ice_acl_lock, &ice_acl);
  	rtp_unload_acl(&stun_acl_lock, &stun_acl);


### PR DESCRIPTION
Why:

* In a rare case where rtp module is restarted and a call comes in,
the stun address is null and asterisk segfaults.  This fix adds a guard
to prevent stun->address from returning a null value