### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,6 +1,5 @@
 git+https://github.com/rsichny/swagger-py.git#egg=swaggerpy
 https://github.com/wazo-platform/ari-py/archive/0.4.0.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
-docker-compose
 pyhamcrest
 pytest


### PR DESCRIPTION
why: to have the latest docker-compose