### PR TITLE
WAZO-2765-remove-existing-mobile

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:18.12.1-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Only allow 1 mobile contact on a given AOR
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 20 May 2022 08:10:57 -0400
+
 asterisk (8:18.12.1-1~wazo1) wazo-dev-buster; urgency=medium
 
   * Asterisk 18.12.1

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -43,9 +43,105 @@ Index: asterisk-18.12.1/res/res_pjsip/location.c
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
 Index: asterisk-18.12.1/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-18.12.1.orig/res/res_pjsip_registrar.c
-+++ asterisk-18.12.1/res/res_pjsip_registrar.c
-@@ -843,6 +843,9 @@ static void register_aor_core(pjsip_rx_d
+--- asterisk-18.12.0.orig/res/res_pjsip_registrar.c
++++ asterisk-18.12.0/res/res_pjsip_registrar.c
+@@ -553,6 +553,35 @@ static int vec_contact_add(void *obj, vo
+ 	return 0;
+ }
+ 
++static int vec_contact_add_mobile(void *obj, void *arg, int flags)
++{
++	struct ast_sip_contact *contact = obj;
++	struct excess_contact_vector *contact_vec = arg;
++
++	/* We only care about mobile contacts here */
++	if (strcmp(contact->mobility, "mobile")) {
++		return 0;
++	}
++
++	/*
++	 * Performance wise, an insertion sort is fine because we
++	 * shouldn't need to remove more than a handful of contacts.
++	 * I expect we'll typically be removing only one contact.
++	 */
++	AST_VECTOR_ADD_SORTED(contact_vec, contact, vec_contact_cmp);
++	if (AST_VECTOR_SIZE(contact_vec) == AST_VECTOR_MAX_SIZE(contact_vec)) {
++		/*
++		 * We added a contact over the number we need to remove.
++		 * Remove the longest to expire contact from the vector
++		 * which is the last element in the vector.  It may be
++		 * the one we just added or the one we just added pushed
++		 * out an earlier contact from removal consideration.
++		 */
++		--AST_VECTOR_SIZE(contact_vec);
++	}
++	return 0;
++}
++
+ /*!
+  * \internal
+  * \brief Remove excess existing contacts that are unavailable or expire soonest.
+@@ -605,6 +634,51 @@ static void remove_excess_contacts(struc
+ 	AST_VECTOR_FREE(&contact_vec);
+ }
+ 
++/*!
++ * \internal
++ * \brief Remove existing mobile contacts.
++ * \since Wazo 22.08
++ *
++ * \param contacts Container of unmodified contacts that could remove.
++ */
++static void remove_remaining_mobile_contacts(struct ao2_container *contacts, struct ao2_container *response_contacts)
++{
++	struct excess_contact_vector contact_vec;
++	int to_remove = 1; /* There will always be a maximum of 1 mobile contact */
++
++	/*
++	 * Create a sorted vector to hold the to_remove soonest to
++	 * expire contacts.  The vector has an extra space to
++	 * temporarily hold the longest to expire contact that we
++	 * won't remove.
++	 */
++	if (AST_VECTOR_INIT(&contact_vec, to_remove + 1)) {
++		return;
++	}
++	ao2_callback(contacts, OBJ_NODATA | OBJ_MULTIPLE, vec_contact_add_mobile, &contact_vec);
++
++	/*
++	 * The vector should always be populated with the number
++	 * of contacts we need to remove.  Just in case, we will
++	 * remove all contacts in the vector even if the contacts
++	 * container had fewer contacts than there should be.
++	 */
++	ast_assert(AST_VECTOR_SIZE(&contact_vec) == to_remove);
++	to_remove = AST_VECTOR_SIZE(&contact_vec);
++
++	/* Remove the excess contacts that are unavailable or expire the soonest */
++	while (to_remove--) {
++		struct ast_sip_contact *contact;
++
++		contact = AST_VECTOR_GET(&contact_vec, to_remove);
++		registrar_contact_delete(CONTACT_DELETE_EXISTING, NULL, contact, contact->aor);
++
++		ao2_unlink(response_contacts, contact);
++	}
++
++	AST_VECTOR_FREE(&contact_vec);
++}
++
+ /*! \brief Callback function which adds non-permanent contacts to a container */
+ static int registrar_add_non_permanent(void *obj, void *arg, int flags)
+ {
+@@ -664,6 +738,7 @@ static void register_aor_core(pjsip_rx_d
+ 	int deleted = 0;
+ 	int permanent = 0;
+ 	int contact_count;
++	int mobile = 0;
+ 	struct ao2_container *existing_contacts = NULL;
+ 	struct ao2_container *unavail_contacts = NULL;
+ 	pjsip_contact_hdr *contact_hdr = (pjsip_contact_hdr *)&rdata->msg_info.msg->hdr;
+@@ -843,6 +918,9 @@ static void register_aor_core(pjsip_rx_d
  
  		if (!contact) {
  			int prune_on_boot;
@@ -55,13 +151,14 @@ Index: asterisk-18.12.1/res/res_pjsip_registrar.c
  
  			/* If they are actually trying to delete a contact that does not exist... be forgiving */
  			if (!expiration) {
-@@ -851,12 +854,19 @@ static void register_aor_core(pjsip_rx_d
+@@ -851,12 +929,20 @@ static void register_aor_core(pjsip_rx_d
  				continue;
  			}
  
 +			mobility_param = pjsip_param_find(&contact_hdr->other_param, &mobility_str);
 +			if (mobility_param) {
 +				ast_copy_pj_str2(&mobility, &mobility_param->value);
++				mobile = strcmp(mobility, "mobile") ? 0 : 1;
 +			}
 +
  			prune_on_boot = !ast_sip_will_uri_survive_restart(details.uri, endpoint, rdata);
@@ -76,7 +173,24 @@ Index: asterisk-18.12.1/res/res_pjsip_registrar.c
  			if (!contact) {
  				ast_log(LOG_ERROR, "Unable to bind contact '%s' to AOR '%s'\n",
  					contact_uri, aor_name);
-Index: asterisk-18.12.1/include/asterisk/res_pjsip.h
+@@ -968,9 +1054,16 @@ static void register_aor_core(pjsip_rx_d
+ 			remove_excess_contacts(existing_contacts, contacts, contact_count - aor->max_contacts,
+ 				aor->remove_existing);
+ 		}
++		/*
++		* If the new contact is mobile then any existing mobile contact should be removed
++		*/
++		if (mobile) {
++			remove_remaining_mobile_contacts(existing_contacts, contacts);
++		}
+ 		ao2_ref(existing_contacts, -1);
+ 	}
+ 
++
+ 	response_contact = ao2_callback(contacts, 0, NULL, NULL);
+ 
+ 	/* Send a response containing all of the contacts (including static) that are present on this AOR */
+Index: asterisk-18.12.0/include/asterisk/res_pjsip.h
 ===================================================================
 --- asterisk-18.12.1.orig/include/asterisk/res_pjsip.h
 +++ asterisk-18.12.1/include/asterisk/res_pjsip.h


### PR DESCRIPTION
for any given AOR only one mobile contact can be registered