### PR TITLE
WAZO-2860: Close file on error playing beep

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:19.5.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Close beep file if failed to stream
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 23 Aug 2022 15:11:58 -0400
+
 asterisk (8:19.5.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Asterisk 19.5.0

--- a/debian/patches/mixmonitor_close_beep_file
+++ b/debian/patches/mixmonitor_close_beep_file
@@ -1,0 +1,26 @@
+Index: asterisk-src/apps/app_mixmonitor.c
+===================================================================
+--- asterisk-src.orig/apps/app_mixmonitor.c
++++ asterisk-src/apps/app_mixmonitor.c
+@@ -815,7 +815,9 @@ static void *mixmonitor_thread(void *obj
+ 
+ 	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {
+ 		ast_autochan_channel_lock(mixmonitor->autochan);
+-		ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "");
++		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "")) {
++			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
++		}
+ 		ast_autochan_channel_unlock(mixmonitor->autochan);
+ 	}
+ 
+@@ -893,7 +895,9 @@ static int setup_mixmonitor_ds(struct mi
+ 
+ 	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_START)) {
+ 		ast_autochan_channel_lock(mixmonitor->autochan);
+-		ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "");
++		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "")) {
++			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
++		}
+ 		ast_autochan_channel_unlock(mixmonitor->autochan);
+ 	}
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -24,3 +24,4 @@ wazo_bridge_variables
 wazo_mixmonitor_events
 wazo_stun_recurring_resolution
 increase-max-sdp-media
+mixmonitor_close_beep_file


### PR DESCRIPTION
If channel is hungup before the beep is played, the file descriptor will stay stuck opened.

This happens when a user does not stop recording before hanging up.  The beep file and the stream will be 
opened but won't play and resources will not be cleaned up afterwards.

This patch makes sure to close the stream (and the file) if the beep couldn't be played.


_Strategy to test this issue:_

1. Get asterisk proc_id: ps -C asterisk
2. ls -la /proc/{procid}/fd
3. check list to see if any are using beep.slin
4. Call a number that will answer (*10 works) and start recording (*3 by default), then end the call (without stopping recording).
5. Repeat step 4 multiple time
6. repeat step 2 and 3 (without fix, should be multiple `beep.slin` still opened)