### PR TITLE
Fix geoloc datastore

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-asterisk (8:19.6.0-1~wazo2) wazo-dev-buster; urgency=medium
+asterisk (8:19.6.0-1~wazo1) UNRELEASED; urgency=medium
 
   * Asterisk 19.6.0
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-asterisk (8:19.6.0-1~wazo1) UNRELEASED; urgency=medium
+asterisk (8:19.6.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Fix geolocation datastore double-free bug
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 13 Oct 2022 13:01:14 -0400
+
+asterisk (8:19.6.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Asterisk 19.6.0
 

--- a/debian/patches/geolocation_datastore_fix
+++ b/debian/patches/geolocation_datastore_fix
@@ -1,0 +1,22 @@
+Index: asterisk-19.6.0/res/res_geolocation/geoloc_datastore.c
+===================================================================
+--- asterisk-19.6.0.orig/res/res_geolocation/geoloc_datastore.c
++++ asterisk-19.6.0/res/res_geolocation/geoloc_datastore.c
+@@ -255,7 +255,7 @@ struct ast_datastore *ast_geoloc_datasto
+ 	}
+ 
+ 	rc = ast_geoloc_datastore_add_eprofile(ds, eprofile);
+-	if (rc != 0) {
++	if (rc <= 0) {
+ 		ast_datastore_free(ds);
+ 		ds = NULL;
+ 	}
+@@ -297,7 +297,7 @@ struct ast_datastore *ast_geoloc_datasto
+ 
+ 	rc = ast_geoloc_datastore_add_eprofile(ds, eprofile);
+ 	ao2_ref(eprofile, -1);
+-	if (rc != 0) {
++	if (rc <= 0) {
+ 		ast_datastore_free(ds);
+ 		ds = NULL;
+ 	}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,4 @@ wazo_mixmonitor_events
 wazo_stun_recurring_resolution
 increase-max-sdp-media
 mixmonitor_close_beep_file
+geolocation_datastore_fix


### PR DESCRIPTION
The function used in the geoloc datastore does not return 0 on success, it returns the size of the underlying vector. The code checking for the error was therefore wrong and caused a double-free situation.