### PR TITLE
use debhelper to install asterisk.service file

### DIFF
--- a/debian/asterisk.dirs
+++ b/debian/asterisk.dirs
@@ -20,6 +20,7 @@ var/spool/asterisk/tmp
 var/spool/asterisk/voicemail
 var/spool/asterisk/outgoing
 
-var/spool/asterisk/recording
-var/lib/asterisk/moh/default
 usr/share/asterisk/firmware/iax
+var/lib/asterisk/agi-bin
+var/lib/asterisk/moh/default
+var/spool/asterisk/recording

--- a/debian/asterisk.install
+++ b/debian/asterisk.install
@@ -11,5 +11,4 @@ usr/share/asterisk/keys /var/lib/asterisk/
 usr/share/asterisk/static-http
 var/lib/asterisk/documentation/thirdparty /usr/share/asterisk/documentation/
 
-debian/asterisk.service lib/systemd/system/
 debian/asterisk_fix /usr/share/asterisk/bin/

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:20.1.0-1~wazo4) wazo-dev-buster; urgency=medium
+
+  * Use dh-systemd to install asterisk.service file
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 06 Mar 2023 07:44:36 -0500
+
 asterisk (8:20.1.0-1~wazo3) wazo-dev-buster; urgency=medium
 
   * Refactor to match upstream debian packaging (i.e. use debhelper)

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends:
  autoconf,
  automake,
  debhelper (>= 10),
+ dh-systemd,
  freetds-dev,
  libasound2-dev,
  libbluetooth-dev,


### PR DESCRIPTION
why: dh-systemd is included in debhelper 12. It will also remove a patch
for asterisk-vanilla and asterisk-debug