### PR TITLE
remove unused dh-systemd dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:20.1.0-1~wazo5) wazo-dev-buster; urgency=medium
+
+  * remove dh-systemd dependency, since already in debhelper 10
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 07 Mar 2023 14:47:36 -0500
+
 asterisk (8:20.1.0-1~wazo4) wazo-dev-buster; urgency=medium
 
   * Use dh-systemd to install asterisk.service file

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Build-Depends:
  autoconf,
  automake,
  debhelper (>= 10),
- dh-systemd,
  freetds-dev,
  libasound2-dev,
  libbluetooth-dev,


### PR DESCRIPTION
why: dh-systemd is already included in debhelper 10