### PR TITLE
res_musiconhold: remove invalid moh class when it cannot playback

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:20.2.1-1~wazo7) wazo-dev-bullseye; urgency=medium
+
+  * Add res_musiconhold patch that fixes invalid file format from stopping moh
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 2 May 2023 11:10:54 -0400
+
 asterisk (8:20.2.1-1~wazo6) wazo-dev-bullseye; urgency=medium
 
   * rebuild

--- a/debian/patches/fix-invalid-moh
+++ b/debian/patches/fix-invalid-moh
@@ -1,0 +1,31 @@
+Index: asterisk-20.2.1/res/res_musiconhold.c
+===================================================================
+--- asterisk-20.2.1.orig/res/res_musiconhold.c
++++ asterisk-20.2.1/res/res_musiconhold.c
+@@ -371,7 +371,9 @@ static int ast_moh_files_next(struct ast
+ 		state->samples = 0;
+ 	}
+ 
++	ast_debug(1, "Got %d files to try.\n", file_count);
+ 	for (tries = 0; tries < file_count; ++tries) {
++		ast_debug(1, "Trying file '%s'\n", AST_VECTOR_GET(files, state->pos));
+ 		if (ast_openstream_full(chan, AST_VECTOR_GET(files, state->pos), ast_channel_language(chan), 1)) {
+ 			break;
+ 		}
+@@ -382,6 +384,8 @@ static int ast_moh_files_next(struct ast
+ 	}
+ 
+ 	if (tries == file_count) {
++		ast_log(LOG_WARNING, "Reached maximum tries. Aborting.");
++		ao2_t_unlink(mohclasses, state->class, "Removing MOH class from container");
+ 		ao2_ref(files, -1);
+ 		return -1;
+ 	}
+@@ -476,6 +480,7 @@ static int moh_files_generator(struct as
+ 		 */
+ 		ast_channel_unlock(chan);
+ 		if (!f) {
++			ast_log(LOG_WARNING, "Could not read frame for '%s'", state->class->name);
+ 			return -1;
+ 		}
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,4 @@ wazo_mixmonitor_events
 wazo_stun_recurring_resolution
 increase-max-sdp-media
 mixmonitor_close_beep_file
+fix-invalid-moh


### PR DESCRIPTION
Why: if an invalid WAV file is provided in a MOH class, it causes
asterisk to stop playback of the music. In the case of a call transfer,
people may hear eachother when it is unwanted. Call holding also does
not work because the music never plays.

This patch fixes the issue by removing the culprit MOH class. However,
it only works after the first occurence of the issue. The first time the
MOH is played will still present the problematic behavior.