### PR TITLE
asterisk 20.5.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:20.5.0-1~wazo1) wazo-dev-bullseye; urgency=medium
+
+  * Asterisk 20.5.0
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 31 Oct 2023 08:44:23 -0400
+
 asterisk (8:20.4.0-1~wazo9) wazo-dev-bullseye; urgency=medium
 
   * backport Asterisk memory leak fix

--- a/debian/patches/ASTERISK-386-memory-load-ephemeral-dtls-certs
+++ b/debian/patches/ASTERISK-386-memory-load-ephemeral-dtls-certs
@@ -6,10 +6,10 @@ Date:   Wed Oct 25 18:19:13 2023 -0400
     
     Fixes #386
 
-Index: asterisk-20.4.0/res/res_rtp_asterisk.c
+Index: asterisk-20.5.0/res/res_rtp_asterisk.c
 ===================================================================
---- asterisk-20.4.0.orig/res/res_rtp_asterisk.c
-+++ asterisk-20.4.0/res/res_rtp_asterisk.c
+--- asterisk-20.5.0.orig/res/res_rtp_asterisk.c
++++ asterisk-20.5.0/res/res_rtp_asterisk.c
 @@ -2032,9 +2032,12 @@ static int create_ephemeral_certificate(
  	if (!(serial = BN_new())
  	   || !BN_rand(serial, SERIAL_RAND_BITS, -1, 0)

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-20.4.0/contrib/scripts/astgenkey
+Index: asterisk-20.5.0/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-20.4.0.orig/contrib/scripts/astgenkey
-+++ asterisk-20.4.0/contrib/scripts/astgenkey
+--- asterisk-20.5.0.orig/contrib/scripts/astgenkey
++++ asterisk-20.5.0/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,10 +3,10 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-20.4.0/Makefile
+Index: asterisk-20.5.0/Makefile
 ===================================================================
---- asterisk-20.4.0.orig/Makefile
-+++ asterisk-20.4.0/Makefile
+--- asterisk-20.5.0.orig/Makefile
++++ asterisk-20.5.0/Makefile
 @@ -443,7 +443,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean

--- a/debian/patches/fix-invalid-moh
+++ b/debian/patches/fix-invalid-moh
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/res/res_musiconhold.c
+Index: asterisk-20.5.0/res/res_musiconhold.c
 ===================================================================
---- asterisk-20.4.0.orig/res/res_musiconhold.c
-+++ asterisk-20.4.0/res/res_musiconhold.c
+--- asterisk-20.5.0.orig/res/res_musiconhold.c
++++ asterisk-20.5.0/res/res_musiconhold.c
 @@ -377,7 +377,9 @@ static int ast_moh_files_next(struct ast
  		state->samples = 0;
  	}

--- a/debian/patches/increase-max-sdp-media
+++ b/debian/patches/increase-max-sdp-media
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/third-party/pjproject/patches/config_site.h
+Index: asterisk-20.5.0/third-party/pjproject/patches/config_site.h
 ===================================================================
---- asterisk-20.4.0.orig/third-party/pjproject/patches/config_site.h
-+++ asterisk-20.4.0/third-party/pjproject/patches/config_site.h
+--- asterisk-20.5.0.orig/third-party/pjproject/patches/config_site.h
++++ asterisk-20.5.0/third-party/pjproject/patches/config_site.h
 @@ -77,8 +77,8 @@
  /* Increase limits to allow more formats */
  #define	PJMEDIA_MAX_SDP_FMT   64

--- a/debian/patches/mixmonitor_close_beep_file
+++ b/debian/patches/mixmonitor_close_beep_file
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/apps/app_mixmonitor.c
+Index: asterisk-20.5.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_mixmonitor.c
-+++ asterisk-20.4.0/apps/app_mixmonitor.c
+--- asterisk-20.5.0.orig/apps/app_mixmonitor.c
++++ asterisk-20.5.0/apps/app_mixmonitor.c
 @@ -829,7 +829,9 @@ static void *mixmonitor_thread(void *obj
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-20.4.0/res/ari.make
+Index: asterisk-20.5.0/res/ari.make
 ===================================================================
---- asterisk-20.4.0.orig/res/ari.make
-+++ asterisk-20.4.0/res/ari.make
+--- asterisk-20.5.0.orig/res/ari.make
++++ asterisk-20.5.0/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-20.4.0/res/ari/resource_wazo.c
+Index: asterisk-20.5.0/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-20.4.0/res/ari/resource_wazo.c
++++ asterisk-20.5.0/res/ari/resource_wazo.c
 @@ -0,0 +1,409 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -421,10 +421,10 @@ Index: asterisk-20.4.0/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-20.4.0/res/ari/resource_wazo.h
+Index: asterisk-20.5.0/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-20.4.0/res/ari/resource_wazo.h
++++ asterisk-20.5.0/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -626,10 +626,10 @@ Index: asterisk-20.4.0/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-20.4.0/res/res_ari_wazo.c
+Index: asterisk-20.5.0/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-20.4.0/res/res_ari_wazo.c
++++ asterisk-20.5.0/res/res_ari_wazo.c
 @@ -0,0 +1,596 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1227,10 +1227,10 @@ Index: asterisk-20.4.0/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-20.4.0/rest-api/api-docs/wazo.json
+Index: asterisk-20.5.0/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-20.4.0/rest-api/api-docs/wazo.json
++++ asterisk-20.5.0/rest-api/api-docs/wazo.json
 @@ -0,0 +1,300 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1532,10 +1532,10 @@ Index: asterisk-20.4.0/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-20.4.0/rest-api/resources.json
+Index: asterisk-20.5.0/rest-api/resources.json
 ===================================================================
---- asterisk-20.4.0.orig/rest-api/resources.json
-+++ asterisk-20.4.0/rest-api/resources.json
+--- asterisk-20.5.0.orig/rest-api/resources.json
++++ asterisk-20.5.0/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1547,10 +1547,10 @@ Index: asterisk-20.4.0/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-20.4.0/include/asterisk/app.h
+Index: asterisk-20.5.0/include/asterisk/app.h
 ===================================================================
---- asterisk-20.4.0.orig/include/asterisk/app.h
-+++ asterisk-20.4.0/include/asterisk/app.h
+--- asterisk-20.5.0.orig/include/asterisk/app.h
++++ asterisk-20.5.0/include/asterisk/app.h
 @@ -564,6 +564,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1640,10 +1640,10 @@ Index: asterisk-20.4.0/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-20.4.0/main/app.c
+Index: asterisk-20.5.0/main/app.c
 ===================================================================
---- asterisk-20.4.0.orig/main/app.c
-+++ asterisk-20.4.0/main/app.c
+--- asterisk-20.5.0.orig/main/app.c
++++ asterisk-20.5.0/main/app.c
 @@ -806,6 +806,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1703,11 +1703,11 @@ Index: asterisk-20.4.0/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-20.4.0/apps/app_voicemail.c
+Index: asterisk-20.5.0/apps/app_voicemail.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_voicemail.c
-+++ asterisk-20.4.0/apps/app_voicemail.c
-@@ -548,6 +548,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
+--- asterisk-20.5.0.orig/apps/app_voicemail.c
++++ asterisk-20.5.0/apps/app_voicemail.c
+@@ -649,6 +649,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
  
@@ -1718,7 +1718,7 @@ Index: asterisk-20.4.0/apps/app_voicemail.c
  #define MAX_DATETIME_FORMAT	512
  #define MAX_NUM_CID_CONTEXTS 10
  
-@@ -1076,6 +1080,13 @@ static int vm_msg_forward(const char *fr
+@@ -1178,6 +1182,13 @@ static int vm_msg_forward(const char *fr
  static int vm_msg_move(const char *mailbox, const char *context, size_t num_msgs, const char *oldfolder, const char *old_msg_ids[], const char *newfolder);
  static int vm_msg_remove(const char *mailbox, const char *context, size_t num_msgs, const char *folder, const char *msgs[]);
  static int vm_msg_play(struct ast_channel *chan, const char *mailbox, const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb cb);
@@ -1732,7 +1732,7 @@ Index: asterisk-20.4.0/apps/app_voicemail.c
  
  #ifdef TEST_FRAMEWORK
  static int vm_test_destroy_user(const char *context, const char *mailbox);
-@@ -14992,6 +15003,10 @@ static const struct ast_vm_functions vm_
+@@ -15700,6 +15711,10 @@ static const struct ast_vm_functions vm_
  	.msg_remove = vm_msg_remove,
  	.msg_forward = vm_msg_forward,
  	.msg_play = vm_msg_play,
@@ -1743,7 +1743,7 @@ Index: asterisk-20.4.0/apps/app_voicemail.c
  };
  
  static const struct ast_vm_greeter_functions vm_greeter_table = {
-@@ -16563,6 +16578,191 @@ play2_msg_cleanup:
+@@ -17279,6 +17294,191 @@ play2_msg_cleanup:
  	return res;
  }
  
@@ -1935,10 +1935,10 @@ Index: asterisk-20.4.0/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-20.4.0/main/http.c
+Index: asterisk-20.5.0/main/http.c
 ===================================================================
---- asterisk-20.4.0.orig/main/http.c
-+++ asterisk-20.4.0/main/http.c
+--- asterisk-20.5.0.orig/main/http.c
++++ asterisk-20.5.0/main/http.c
 @@ -82,7 +82,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */

--- a/debian/patches/wazo_banner
+++ b/debian/patches/wazo_banner
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/main/asterisk.c
+Index: asterisk-20.5.0/main/asterisk.c
 ===================================================================
---- asterisk-20.4.0.orig/main/asterisk.c
-+++ asterisk-20.4.0/main/asterisk.c
+--- asterisk-20.5.0.orig/main/asterisk.c
++++ asterisk-20.5.0/main/asterisk.c
 @@ -307,6 +307,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \

--- a/debian/patches/wazo_bridge_variables
+++ b/debian/patches/wazo_bridge_variables
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/include/asterisk/bridge.h
+Index: asterisk-20.5.0/include/asterisk/bridge.h
 ===================================================================
---- asterisk-20.4.0.orig/include/asterisk/bridge.h
-+++ asterisk-20.4.0/include/asterisk/bridge.h
+--- asterisk-20.5.0.orig/include/asterisk/bridge.h
++++ asterisk-20.5.0/include/asterisk/bridge.h
 @@ -249,6 +249,31 @@ typedef void (*ast_bridge_notify_masquer
  typedef int (*ast_bridge_merge_priority_fn)(struct ast_bridge *self);
  
@@ -85,10 +85,10 @@ Index: asterisk-20.4.0/include/asterisk/bridge.h
  #if defined(__cplusplus) || defined(c_plusplus)
  }
  #endif
-Index: asterisk-20.4.0/main/bridge.c
+Index: asterisk-20.5.0/main/bridge.c
 ===================================================================
---- asterisk-20.4.0.orig/main/bridge.c
-+++ asterisk-20.4.0/main/bridge.c
+--- asterisk-20.5.0.orig/main/bridge.c
++++ asterisk-20.5.0/main/bridge.c
 @@ -118,6 +118,8 @@
  #include "asterisk/core_local.h"
  #include "asterisk/core_unreal.h"
@@ -151,10 +151,10 @@ Index: asterisk-20.4.0/main/bridge.c
  static int manager_bridge_tech_list(struct mansession *s, const struct message *m)
  {
  	const char *id = astman_get_header(m, "ActionID");
-Index: asterisk-20.4.0/res/ari/resource_bridges.c
+Index: asterisk-20.5.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-20.4.0.orig/res/ari/resource_bridges.c
-+++ asterisk-20.4.0/res/ari/resource_bridges.c
+--- asterisk-20.5.0.orig/res/ari/resource_bridges.c
++++ asterisk-20.5.0/res/ari/resource_bridges.c
 @@ -44,6 +44,10 @@
  #include "asterisk/file.h"
  #include "asterisk/musiconhold.h"
@@ -288,10 +288,10 @@ Index: asterisk-20.4.0/res/ari/resource_bridges.c
 +	ast_ari_response_ok(response, response->message);
 +}
 \ No newline at end of file
-Index: asterisk-20.4.0/res/ari/resource_bridges.h
+Index: asterisk-20.5.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-20.4.0.orig/res/ari/resource_bridges.h
-+++ asterisk-20.4.0/res/ari/resource_bridges.h
+--- asterisk-20.5.0.orig/res/ari/resource_bridges.h
++++ asterisk-20.5.0/res/ari/resource_bridges.h
 @@ -395,5 +395,59 @@ int ast_ari_bridges_record_parse_body(
   * \param[out] response HTTP response
   */
@@ -352,10 +352,10 @@ Index: asterisk-20.4.0/res/ari/resource_bridges.h
 +void ast_ari_bridges_set_bridge_var(struct ast_variable *headers, struct ast_ari_bridges_set_bridge_var_args *args, struct ast_ari_response *response);
  
  #endif /* _ASTERISK_RESOURCE_BRIDGES_H */
-Index: asterisk-20.4.0/res/res_ari_bridges.c
+Index: asterisk-20.5.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-20.4.0.orig/res/res_ari_bridges.c
-+++ asterisk-20.4.0/res/res_ari_bridges.c
+--- asterisk-20.5.0.orig/res/res_ari_bridges.c
++++ asterisk-20.5.0/res/res_ari_bridges.c
 @@ -1489,6 +1489,179 @@ static void ast_ari_bridges_record_cb(
  fin: __attribute__((unused))
  	return;
@@ -564,10 +564,10 @@ Index: asterisk-20.4.0/res/res_ari_bridges.c
  };
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges = {
-Index: asterisk-20.4.0/rest-api/api-docs/bridges.json
+Index: asterisk-20.5.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-20.4.0.orig/rest-api/api-docs/bridges.json
-+++ asterisk-20.4.0/rest-api/api-docs/bridges.json
+--- asterisk-20.5.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-20.5.0/rest-api/api-docs/bridges.json
 @@ -574,7 +574,6 @@
  							"reason": "Bridge not in a Stasis application"
  						}
@@ -685,10 +685,10 @@ Index: asterisk-20.4.0/rest-api/api-docs/bridges.json
  				}
  			}
  		}
-Index: asterisk-20.4.0/include/asterisk/stasis_bridges.h
+Index: asterisk-20.5.0/include/asterisk/stasis_bridges.h
 ===================================================================
---- asterisk-20.4.0.orig/include/asterisk/stasis_bridges.h
-+++ asterisk-20.4.0/include/asterisk/stasis_bridges.h
+--- asterisk-20.5.0.orig/include/asterisk/stasis_bridges.h
++++ asterisk-20.5.0/include/asterisk/stasis_bridges.h
 @@ -94,6 +94,9 @@ struct ast_bridge_merge_message {
  	struct ast_bridge_snapshot *to;		/*!< Bridge to which channels will be added during the merge */
  };
@@ -717,10 +717,10 @@ Index: asterisk-20.4.0/include/asterisk/stasis_bridges.h
   * \brief Blob of data associated with a bridge.
   *
   * The \c blob is actually a JSON object of structured data. It has a "type" field
-Index: asterisk-20.4.0/main/stasis_bridges.c
+Index: asterisk-20.5.0/main/stasis_bridges.c
 ===================================================================
---- asterisk-20.4.0.orig/main/stasis_bridges.c
-+++ asterisk-20.4.0/main/stasis_bridges.c
+--- asterisk-20.5.0.orig/main/stasis_bridges.c
++++ asterisk-20.5.0/main/stasis_bridges.c
 @@ -37,6 +37,7 @@
  #include "asterisk/stasis_channels.h"
  #include "asterisk/bridge.h"
@@ -861,10 +861,10 @@ Index: asterisk-20.4.0/main/stasis_bridges.c
  
  	return res;
  }
-Index: asterisk-20.4.0/rest-api/api-docs/events.json
+Index: asterisk-20.5.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-20.4.0.orig/rest-api/api-docs/events.json
-+++ asterisk-20.4.0/rest-api/api-docs/events.json
+--- asterisk-20.5.0.orig/rest-api/api-docs/events.json
++++ asterisk-20.5.0/rest-api/api-docs/events.json
 @@ -162,6 +162,7 @@
  				"ApplicationMoveFailed",
  				"ApplicationReplaced",

--- a/debian/patches/wazo_mixmonitor_events
+++ b/debian/patches/wazo_mixmonitor_events
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/apps/app_mixmonitor.c
+Index: asterisk-20.5.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_mixmonitor.c
-+++ asterisk-20.4.0/apps/app_mixmonitor.c
+--- asterisk-20.5.0.orig/apps/app_mixmonitor.c
++++ asterisk-20.5.0/apps/app_mixmonitor.c
 @@ -968,6 +968,8 @@ static int launch_monitor_thread(struct
  	struct mixmonitor *mixmonitor;
  	char postprocess2[1024] = "";
@@ -91,10 +91,10 @@ Index: asterisk-20.4.0/apps/app_mixmonitor.c
  	return 0;
  }
  
-Index: asterisk-20.4.0/main/cel.c
+Index: asterisk-20.5.0/main/cel.c
 ===================================================================
---- asterisk-20.4.0.orig/main/cel.c
-+++ asterisk-20.4.0/main/cel.c
+--- asterisk-20.5.0.orig/main/cel.c
++++ asterisk-20.5.0/main/cel.c
 @@ -323,6 +323,8 @@ static const char * const cel_event_type
  	[AST_CEL_LINKEDID_END]     = "LINKEDID_END",
  	[AST_CEL_LOCAL_OPTIMIZE]   = "LOCAL_OPTIMIZE",
@@ -155,10 +155,10 @@ Index: asterisk-20.4.0/main/cel.c
  		ast_local_optimization_end_type(),
  		cel_local_optimization_end_cb,
  		NULL);
-Index: asterisk-20.4.0/include/asterisk/cel.h
+Index: asterisk-20.5.0/include/asterisk/cel.h
 ===================================================================
---- asterisk-20.4.0.orig/include/asterisk/cel.h
-+++ asterisk-20.4.0/include/asterisk/cel.h
+--- asterisk-20.5.0.orig/include/asterisk/cel.h
++++ asterisk-20.5.0/include/asterisk/cel.h
 @@ -77,6 +77,10 @@ enum ast_cel_event_type {
  	AST_CEL_LOCAL_OPTIMIZE = 17,
  	/*! \brief A local channel optimization has begun */

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/res/res_pjsip/location.c
+Index: asterisk-20.5.0/res/res_pjsip/location.c
 ===================================================================
---- asterisk-20.4.0.orig/res/res_pjsip/location.c
-+++ asterisk-20.4.0/res/res_pjsip/location.c
+--- asterisk-20.5.0.orig/res/res_pjsip/location.c
++++ asterisk-20.5.0/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,10 +41,10 @@ Index: asterisk-20.4.0/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-20.4.0/res/res_pjsip_registrar.c
+Index: asterisk-20.5.0/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-20.4.0.orig/res/res_pjsip_registrar.c
-+++ asterisk-20.4.0/res/res_pjsip_registrar.c
+--- asterisk-20.5.0.orig/res/res_pjsip_registrar.c
++++ asterisk-20.5.0/res/res_pjsip_registrar.c
 @@ -553,6 +553,35 @@ static int vec_contact_add(void *obj, vo
  	return 0;
  }
@@ -190,11 +190,11 @@ Index: asterisk-20.4.0/res/res_pjsip_registrar.c
  	response_contact = ao2_callback(contacts, 0, NULL, NULL);
  
  	/* Send a response containing all of the contacts (including static) that are present on this AOR */
-Index: asterisk-20.4.0/include/asterisk/res_pjsip.h
+Index: asterisk-20.5.0/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-20.4.0.orig/include/asterisk/res_pjsip.h
-+++ asterisk-20.4.0/include/asterisk/res_pjsip.h
-@@ -403,6 +403,8 @@ struct ast_sip_contact {
+--- asterisk-20.5.0.orig/include/asterisk/res_pjsip.h
++++ asterisk-20.5.0/include/asterisk/res_pjsip.h
+@@ -417,6 +417,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
  		AST_STRING_FIELD(endpoint_name);
@@ -203,7 +203,7 @@ Index: asterisk-20.4.0/include/asterisk/res_pjsip.h
  	);
  	/*! Absolute time that this contact is no longer valid after */
  	struct timeval expiration_time;
-@@ -1717,7 +1719,7 @@ int ast_sip_location_add_contact_nolock(
+@@ -1731,7 +1733,7 @@ int ast_sip_location_add_contact_nolock(
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
  	const char *user_agent, const char *via_addr, int via_port, const char *call_id,
@@ -212,11 +212,11 @@ Index: asterisk-20.4.0/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-20.4.0/res/res_pjsip/pjsip_config.xml
+Index: asterisk-20.5.0/res/res_pjsip/pjsip_config.xml
 ===================================================================
---- asterisk-20.4.0.orig/res/res_pjsip/pjsip_config.xml
-+++ asterisk-20.4.0/res/res_pjsip/pjsip_config.xml
-@@ -1973,6 +1973,12 @@
+--- asterisk-20.5.0.orig/res/res_pjsip/pjsip_config.xml
++++ asterisk-20.5.0/res/res_pjsip/pjsip_config.xml
+@@ -1976,6 +1976,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>
  				</configOption>

--- a/debian/patches/wazo_stun_recurring_resolution
+++ b/debian/patches/wazo_stun_recurring_resolution
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/main/dns_recurring.c
+Index: asterisk-20.5.0/main/dns_recurring.c
 ===================================================================
---- asterisk-20.4.0.orig/main/dns_recurring.c
-+++ asterisk-20.4.0/main/dns_recurring.c
+--- asterisk-20.5.0.orig/main/dns_recurring.c
++++ asterisk-20.5.0/main/dns_recurring.c
 @@ -41,9 +41,13 @@
  
  /*! \brief Delay between TTL expiration and the next DNS query, to make sure the
@@ -44,10 +44,10 @@ Index: asterisk-20.4.0/main/dns_recurring.c
  		}
  	}
  
-Index: asterisk-20.4.0/res/res_rtp_asterisk.c
+Index: asterisk-20.5.0/res/res_rtp_asterisk.c
 ===================================================================
---- asterisk-20.4.0.orig/res/res_rtp_asterisk.c
-+++ asterisk-20.4.0/res/res_rtp_asterisk.c
+--- asterisk-20.5.0.orig/res/res_rtp_asterisk.c
++++ asterisk-20.5.0/res/res_rtp_asterisk.c
 @@ -230,7 +230,7 @@ static int dtls_mtu = DEFAULT_DTLS_MTU;
  #ifdef HAVE_PJPROJECT
  static int icesupport = DEFAULT_ICESUPPORT;
@@ -113,7 +113,7 @@ Index: asterisk-20.4.0/res/res_rtp_asterisk.c
  
  	/* If configured to use a STUN server to get our external mapped address do so */
  	if (stunaddr_copy.sin_addr.s_addr && !stun_address_is_blacklisted(addr) &&
-@@ -9426,70 +9427,175 @@ static int ast_rtp_bundle(struct ast_rtp
+@@ -9422,70 +9423,175 @@ static int ast_rtp_bundle(struct ast_rtp
  }
  
  #ifdef HAVE_PJPROJECT
@@ -335,7 +335,7 @@ Index: asterisk-20.4.0/res/res_rtp_asterisk.c
  }
  #endif
  
-@@ -9626,10 +9732,9 @@ static char *handle_cli_rtp_settings(str
+@@ -9622,10 +9728,9 @@ static char *handle_cli_rtp_settings(str
  #ifdef HAVE_PJPROJECT
  	ast_cli(a->fd, "  ICE support:     %s\n", AST_CLI_YESNO(icesupport));
  
@@ -349,7 +349,7 @@ Index: asterisk-20.4.0/res/res_rtp_asterisk.c
  #endif
  	return CLI_SUCCESS;
  }
-@@ -9878,7 +9983,8 @@ static int rtp_reload(int reload, int by
+@@ -9874,7 +9979,8 @@ static int rtp_reload(int reload, int by
  	icesupport = DEFAULT_ICESUPPORT;
  	stun_software_attribute = DEFAULT_STUN_SOFTWARE_ATTRIBUTE;
  	turnport = DEFAULT_TURN_PORT;
@@ -359,7 +359,7 @@ Index: asterisk-20.4.0/res/res_rtp_asterisk.c
  	turnaddr = pj_str(NULL);
  	turnusername = pj_str(NULL);
  	turnpassword = pj_str(NULL);
-@@ -9956,36 +10062,8 @@ static int rtp_reload(int reload, int by
+@@ -9952,36 +10058,8 @@ static int rtp_reload(int reload, int by
  		stun_software_attribute = ast_true(s);
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "stunaddr"))) {
@@ -398,7 +398,7 @@ Index: asterisk-20.4.0/res/res_rtp_asterisk.c
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "turnaddr"))) {
  		struct sockaddr_in addr;
-@@ -10251,7 +10329,7 @@ static int unload_module(void)
+@@ -10247,7 +10325,7 @@ static int unload_module(void)
  	acl_change_sub = stasis_unsubscribe_and_join(acl_change_sub);
  	rtp_unload_acl(&ice_acl_lock, &ice_acl);
  	rtp_unload_acl(&stun_acl_lock, &stun_acl);

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,8 +1,8 @@
-Index: asterisk-20.4.0/apps/app_queue.c
+Index: asterisk-20.5.0/apps/app_queue.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_queue.c
-+++ asterisk-20.4.0/apps/app_queue.c
-@@ -2369,6 +2369,18 @@ static struct ast_manager_event_blob *qu
+--- asterisk-20.5.0.orig/apps/app_queue.c
++++ asterisk-20.5.0/apps/app_queue.c
+@@ -2374,6 +2374,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;
  		}
@@ -21,7 +21,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	}
  
  	agent = ast_multi_channel_blob_get_channel(obj, "agent");
-@@ -6373,13 +6385,14 @@ static void send_agent_complete(const ch
+@@ -6378,13 +6390,14 @@ static void send_agent_complete(const ch
  		break;
  	}
  

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,8 +1,8 @@
-Index: asterisk-20.4.0/apps/app_queue.c
+Index: asterisk-20.5.0/apps/app_queue.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_queue.c
-+++ asterisk-20.4.0/apps/app_queue.c
-@@ -6356,7 +6356,7 @@ enum agent_complete_reason {
+--- asterisk-20.5.0.orig/apps/app_queue.c
++++ asterisk-20.5.0/apps/app_queue.c
+@@ -6361,7 +6361,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,
  	struct ast_channel_snapshot *peer, const struct member *member, time_t holdstart,
@@ -11,7 +11,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  {
  	const char *reason = NULL;	/* silence dumb compilers */
  	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
-@@ -6373,16 +6373,21 @@ static void send_agent_complete(const ch
+@@ -6378,16 +6378,21 @@ static void send_agent_complete(const ch
  		break;
  	}
  
@@ -34,7 +34,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  }
  
  static void queue_agent_cb(void *userdata, struct stasis_subscription *sub,
-@@ -6677,7 +6682,7 @@ static void handle_blind_transfer(void *
+@@ -6682,7 +6687,7 @@ static void handle_blind_transfer(void *
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -43,7 +43,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -6735,7 +6740,7 @@ static void handle_attended_transfer(voi
+@@ -6740,7 +6745,7 @@ static void handle_attended_transfer(voi
  	log_attended_transfer(queue_data, atxfer_msg);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -52,7 +52,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -6933,7 +6938,7 @@ static void handle_hangup(void *userdata
+@@ -6938,7 +6943,7 @@ static void handle_hangup(void *userdata
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/main/stasis_channels.c
+Index: asterisk-20.5.0/main/stasis_channels.c
 ===================================================================
---- asterisk-20.4.0.orig/main/stasis_channels.c
-+++ asterisk-20.4.0/main/stasis_channels.c
+--- asterisk-20.5.0.orig/main/stasis_channels.c
++++ asterisk-20.5.0/main/stasis_channels.c
 @@ -1609,6 +1609,47 @@ static struct ast_json *unhold_to_json(s
  		"channel", json_channel);
  }
@@ -65,10 +65,10 @@ Index: asterisk-20.4.0/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_monitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_start_type);
-Index: asterisk-20.4.0/rest-api/api-docs/events.json
+Index: asterisk-20.5.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-20.4.0.orig/rest-api/api-docs/events.json
-+++ asterisk-20.4.0/rest-api/api-docs/events.json
+--- asterisk-20.5.0.orig/rest-api/api-docs/events.json
++++ asterisk-20.5.0/rest-api/api-docs/events.json
 @@ -189,7 +189,9 @@
  				"StasisStart",
  				"TextMessageReceived",

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/res/ari/resource_channels.c
+Index: asterisk-20.5.0/res/ari/resource_channels.c
 ===================================================================
---- asterisk-20.4.0.orig/res/ari/resource_channels.c
-+++ asterisk-20.4.0/res/ari/resource_channels.c
+--- asterisk-20.5.0.orig/res/ari/resource_channels.c
++++ asterisk-20.5.0/res/ari/resource_channels.c
 @@ -1553,6 +1553,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-20.4.0/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-20.4.0/res/ari/resource_channels.h
+Index: asterisk-20.5.0/res/ari/resource_channels.h
 ===================================================================
---- asterisk-20.4.0.orig/res/ari/resource_channels.h
-+++ asterisk-20.4.0/res/ari/resource_channels.h
+--- asterisk-20.5.0.orig/res/ari/resource_channels.h
++++ asterisk-20.5.0/res/ari/resource_channels.h
 @@ -693,6 +693,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *variable;
  	/*! The value to set the variable to */
@@ -37,10 +37,10 @@ Index: asterisk-20.4.0/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-20.4.0/res/res_ari_channels.c
+Index: asterisk-20.5.0/res/res_ari_channels.c
 ===================================================================
---- asterisk-20.4.0.orig/res/res_ari_channels.c
-+++ asterisk-20.4.0/res/res_ari_channels.c
+--- asterisk-20.5.0.orig/res/res_ari_channels.c
++++ asterisk-20.5.0/res/res_ari_channels.c
 @@ -2422,6 +2422,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->value = ast_json_string_get(field);
@@ -62,10 +62,10 @@ Index: asterisk-20.4.0/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-20.4.0/rest-api/api-docs/channels.json
+Index: asterisk-20.5.0/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-20.4.0.orig/rest-api/api-docs/channels.json
-+++ asterisk-20.4.0/rest-api/api-docs/channels.json
+--- asterisk-20.5.0.orig/rest-api/api-docs/channels.json
++++ asterisk-20.5.0/rest-api/api-docs/channels.json
 @@ -1478,6 +1478,15 @@
  							"required": false,
  							"allowMultiple": false,

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/main/ccss.c
+Index: asterisk-20.5.0/main/ccss.c
 ===================================================================
---- asterisk-20.4.0.orig/main/ccss.c
-+++ asterisk-20.4.0/main/ccss.c
+--- asterisk-20.5.0.orig/main/ccss.c
++++ asterisk-20.5.0/main/ccss.c
 @@ -2669,6 +2669,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/include/asterisk/channel.h
+Index: asterisk-20.5.0/include/asterisk/channel.h
 ===================================================================
---- asterisk-20.4.0.orig/include/asterisk/channel.h
-+++ asterisk-20.4.0/include/asterisk/channel.h
+--- asterisk-20.5.0.orig/include/asterisk/channel.h
++++ asterisk-20.5.0/include/asterisk/channel.h
 @@ -4483,6 +4483,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
@@ -21,10 +21,10 @@ Index: asterisk-20.4.0/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-20.4.0/main/channel.c
+Index: asterisk-20.5.0/main/channel.c
 ===================================================================
---- asterisk-20.4.0.orig/main/channel.c
-+++ asterisk-20.4.0/main/channel.c
+--- asterisk-20.5.0.orig/main/channel.c
++++ asterisk-20.5.0/main/channel.c
 @@ -11214,3 +11214,8 @@ void ast_channel_clear_flag(struct ast_c
  	ast_clear_flag(ast_channel_flags(chan), flag);
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/main/features.c
+Index: asterisk-20.5.0/main/features.c
 ===================================================================
---- asterisk-20.4.0.orig/main/features.c
-+++ asterisk-20.4.0/main/features.c
+--- asterisk-20.5.0.orig/main/features.c
++++ asterisk-20.5.0/main/features.c
 @@ -673,6 +673,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/include/asterisk/file.h
+Index: asterisk-20.5.0/include/asterisk/file.h
 ===================================================================
---- asterisk-20.4.0.orig/include/asterisk/file.h
-+++ asterisk-20.4.0/include/asterisk/file.h
+--- asterisk-20.5.0.orig/include/asterisk/file.h
++++ asterisk-20.5.0/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,10 +10,10 @@ Index: asterisk-20.4.0/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-20.4.0/main/bridge_basic.c
+Index: asterisk-20.5.0/main/bridge_basic.c
 ===================================================================
---- asterisk-20.4.0.orig/main/bridge_basic.c
-+++ asterisk-20.4.0/main/bridge_basic.c
+--- asterisk-20.5.0.orig/main/bridge_basic.c
++++ asterisk-20.5.0/main/bridge_basic.c
 @@ -3219,7 +3219,7 @@ static int grab_transfer(struct ast_chan
  
  	/* Play the simple "transfer" prompt out and wait */

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,9 +1,9 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-20.4.0/apps/app_queue.c
+Index: asterisk-20.5.0/apps/app_queue.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_queue.c
-+++ asterisk-20.4.0/apps/app_queue.c
-@@ -10411,6 +10411,7 @@ static int manager_queues_summary(struct
+--- asterisk-20.5.0.orig/apps/app_queue.c
++++ asterisk-20.5.0/apps/app_queue.c
+@@ -10459,6 +10459,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;
  	int qmemcount = 0;
@@ -11,7 +11,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	int qmemavail = 0;
  	int qchancount = 0;
  	int qlongestholdtime = 0;
-@@ -10442,6 +10443,7 @@ static int manager_queues_summary(struct
+@@ -10490,6 +10491,7 @@ static int manager_queues_summary(struct
  		if (ast_strlen_zero(queuefilter) || !strcasecmp(q->name, queuefilter)) {
  			/* Reset the necessary local variables if no queuefilter is set*/
  			qmemcount = 0;
@@ -19,7 +19,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			qmemavail = 0;
  			qchancount = 0;
  			qlongestholdtime = 0;
-@@ -10455,6 +10457,9 @@ static int manager_queues_summary(struct
+@@ -10503,6 +10505,9 @@ static int manager_queues_summary(struct
  						++qmemavail;
  					}
  				}
@@ -29,7 +29,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  				ao2_ref(mem, -1);
  			}
  			ao2_iterator_destroy(&mem_iter);
-@@ -10468,13 +10473,14 @@ static int manager_queues_summary(struct
+@@ -10516,13 +10521,14 @@ static int manager_queues_summary(struct
  				"Queue: %s\r\n"
  				"LoggedIn: %d\r\n"
  				"Available: %d\r\n"

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,8 +1,8 @@
-Index: asterisk-20.4.0/apps/app_queue.c
+Index: asterisk-20.5.0/apps/app_queue.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_queue.c
-+++ asterisk-20.4.0/apps/app_queue.c
-@@ -1707,6 +1707,7 @@ struct queue_ent {
+--- asterisk-20.5.0.orig/apps/app_queue.c
++++ asterisk-20.5.0/apps/app_queue.c
+@@ -1710,6 +1710,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
  	char digits[AST_MAX_EXTENSION];        /*!< Digits entered while in queue */
@@ -10,7 +10,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	const char *predial_callee;            /*!< Gosub app arguments for outgoing calls.  NULL if not supplied. */
  	int valid_digits;                      /*!< Digits entered correspond to valid extension. Exited */
  	int pos;                               /*!< Where we are in the queue */
-@@ -2252,6 +2253,20 @@ static struct ast_manager_event_blob *qu
+@@ -2257,6 +2258,20 @@ static struct ast_manager_event_blob *qu
  	RAII_VAR(struct ast_str *, event_string, NULL, ast_free);
  
  	channel_string = ast_manager_build_channel_state_string(obj->snapshot);
@@ -31,7 +31,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	event_string = ast_manager_str_from_json_object(obj->blob, NULL);
  	if (!channel_string || !event_string) {
  		return NULL;
-@@ -4599,10 +4614,11 @@ static void leave_queue(struct queue_ent
+@@ -4604,10 +4619,11 @@ static void leave_queue(struct queue_ent
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  			}
  
@@ -45,7 +45,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			ast_channel_publish_cached_blob(qe->chan, queue_caller_leave_type(), blob);
  			ast_debug(1, "Queue '%s' Leave, Channel '%s'\n", q->name, ast_channel_name(qe->chan));
  			/* Take us out of the queue */
-@@ -8892,6 +8908,8 @@ static int queue_exec(struct ast_channel
+@@ -8940,6 +8956,8 @@ static int queue_exec(struct ast_channel
  	} else {
  		raise_penalty = INT_MAX;
  	}

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,8 +1,8 @@
-Index: asterisk-20.4.0/apps/app_queue.c
+Index: asterisk-20.5.0/apps/app_queue.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_queue.c
-+++ asterisk-20.4.0/apps/app_queue.c
-@@ -4507,7 +4507,7 @@ static int say_position(struct queue_ent
+--- asterisk-20.5.0.orig/apps/app_queue.c
++++ asterisk-20.5.0/apps/app_queue.c
+@@ -4512,7 +4512,7 @@ static int say_position(struct queue_ent
  		}
  
  		if (avgholdmins >= 1) {
@@ -11,7 +11,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			if (res) {
  				goto playout;
  			}
-@@ -4525,7 +4525,7 @@ static int say_position(struct queue_ent
+@@ -4530,7 +4530,7 @@ static int say_position(struct queue_ent
  			}
  		}
  		if (avgholdsecs >= 1) {

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,8 +1,8 @@
-Index: asterisk-20.4.0/apps/app_queue.c
+Index: asterisk-20.5.0/apps/app_queue.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_queue.c
-+++ asterisk-20.4.0/apps/app_queue.c
-@@ -6710,10 +6710,10 @@ static void handle_blind_transfer(void *
+--- asterisk-20.5.0.orig/apps/app_queue.c
++++ asterisk-20.5.0/apps/app_queue.c
+@@ -6715,10 +6715,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
@@ -15,7 +15,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -6768,10 +6768,10 @@ static void handle_attended_transfer(voi
+@@ -6773,10 +6773,10 @@ static void handle_attended_transfer(voi
  	ast_debug(3, "Detected attended transfer in queue %s\n", queue_data->queue->name);
  	log_attended_transfer(queue_data, atxfer_msg);
  
@@ -28,7 +28,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -6966,10 +6966,10 @@ static void handle_hangup(void *userdata
+@@ -6971,10 +6971,10 @@ static void handle_hangup(void *userdata
  		(long) (queue_data->starttime - queue_data->holdstart),
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/main/channel.c
+Index: asterisk-20.5.0/main/channel.c
 ===================================================================
---- asterisk-20.4.0.orig/main/channel.c
-+++ asterisk-20.4.0/main/channel.c
+--- asterisk-20.5.0.orig/main/channel.c
++++ asterisk-20.5.0/main/channel.c
 @@ -4937,7 +4937,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_sip_tel_uri
+++ b/debian/patches/xivo_sip_tel_uri
@@ -1,7 +1,7 @@
-Index: asterisk-20.4.0/channels/sip/reqresp_parser.c
+Index: asterisk-20.5.0/channels/sip/reqresp_parser.c
 ===================================================================
---- asterisk-20.4.0.orig/channels/sip/reqresp_parser.c
-+++ asterisk-20.4.0/channels/sip/reqresp_parser.c
+--- asterisk-20.5.0.orig/channels/sip/reqresp_parser.c
++++ asterisk-20.5.0/channels/sip/reqresp_parser.c
 @@ -925,7 +925,7 @@ int get_name_and_number(const char *hdr,
  	tmp_number = get_in_brackets(header);
  

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,8 +1,8 @@
-Index: asterisk-20.4.0/apps/app_queue.c
+Index: asterisk-20.5.0/apps/app_queue.c
 ===================================================================
---- asterisk-20.4.0.orig/apps/app_queue.c
-+++ asterisk-20.4.0/apps/app_queue.c
-@@ -1529,6 +1529,8 @@ enum queue_reload_mask {
+--- asterisk-20.5.0.orig/apps/app_queue.c
++++ asterisk-20.5.0/apps/app_queue.c
+@@ -1532,6 +1532,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
  	QUEUE_RESET_STATS = (1 << 3),
@@ -11,7 +11,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  };
  
  static const struct strategy {
-@@ -1693,9 +1695,14 @@ struct callattempt {
+@@ -1696,9 +1698,14 @@ struct callattempt {
  	char *orig_chan_name;
  };
  
@@ -26,7 +26,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	char moh[MAX_MUSICCLASS];              /*!< Name of musiconhold to be used */
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
-@@ -1717,8 +1724,11 @@ struct queue_ent {
+@@ -1720,8 +1727,11 @@ struct queue_ent {
  	int raise_penalty;                     /*!< Float lower penalty members to a minimum penalty */
  	int linpos;                            /*!< If using linear strategy, what position are we at? */
  	int linwrapped;                        /*!< Is the linpos wrapped? */
@@ -38,7 +38,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	int cancel_answered_elsewhere;         /*!< Whether we should force the CAE flag on this call (C) option*/
  	unsigned int withdraw:1;               /*!< Should this call exit the queue at its next iteration? Used for QueueWithdrawCaller */
  	char *withdraw_info;                   /*!< Optional info passed by the caller of QueueWithdrawCaller */
-@@ -1728,6 +1738,89 @@ struct queue_ent {
+@@ -1731,6 +1741,89 @@ struct queue_ent {
  	struct queue_ent *next;                /*!< The next queue entry */
  };
  
@@ -128,7 +128,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  struct member {
  	char interface[AST_CHANNEL_NAME];    /*!< Technology/Location to dial to reach this member*/
  	char state_exten[AST_MAX_EXTENSION]; /*!< Extension to get state from (if using hint) */
-@@ -1735,6 +1828,7 @@ struct member {
+@@ -1738,6 +1831,7 @@ struct member {
  	char state_interface[AST_CHANNEL_NAME]; /*!< Technology/Location from which to read devicestate changes */
  	int state_id;                        /*!< Extension state callback id (if using hint) */
  	char membername[80];                 /*!< Member name to use in queue logs */
@@ -136,7 +136,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	int penalty;                         /*!< Are we a last resort? */
  	int calls;                           /*!< Number of calls serviced by this member */
  	int dynamic;                         /*!< Are we dynamically added? */
-@@ -1743,6 +1837,7 @@ struct member {
+@@ -1746,6 +1840,7 @@ struct member {
  	int paused;                          /*!< Are we paused (not accepting calls)? */
  	char reason_paused[80];              /*!< Reason of paused if member is paused */
  	int queuepos;                        /*!< In what order (pertains to certain strategies) should this member be called? */
@@ -144,7 +144,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	int callcompletedinsl;               /*!< Whether the current call was completed within service level */
  	int wrapuptime;                      /*!< Wrapup Time */
  	time_t starttime;                    /*!< The time at which the member answered the current caller. */
-@@ -1889,6 +1984,7 @@ struct call_queue {
+@@ -1892,6 +1987,7 @@ struct call_queue {
  	int memberdelay;                    /*!< Seconds to delay connecting member to caller */
  	int autofill;                       /*!< Ignore the head call status and ring an available agent */
  
@@ -152,7 +152,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	struct ao2_container *members;      /*!< Head of the list of members */
  	struct queue_ent *head;             /*!< Head of the list of callers */
  	AST_LIST_ENTRY(call_queue) list;    /*!< Next call queue */
-@@ -1911,6 +2007,40 @@ static int set_member_paused(const char
+@@ -1914,6 +2010,40 @@ static int set_member_paused(const char
  static int update_queue(struct call_queue *q, struct member *member, int callcompletedinsl, time_t starttime);
  
  static struct member *find_member_by_queuename_and_interface(const char *queuename, const char *interface);
@@ -193,7 +193,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  /*! \brief sets the QUEUESTATUS channel variable */
  static void set_queue_result(struct ast_channel *chan, enum queue_result res)
  {
-@@ -2397,7 +2527,7 @@ static void queue_publish_member_blob(st
+@@ -2402,7 +2532,7 @@ static void queue_publish_member_blob(st
  
  static struct ast_json *queue_member_blob_create(struct call_queue *q, struct member *mem)
  {
@@ -202,7 +202,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		"Queue", q->name,
  		"MemberName", mem->membername,
  		"Interface", mem->interface,
-@@ -2413,7 +2543,8 @@ static struct ast_json *queue_member_blo
+@@ -2418,7 +2548,8 @@ static struct ast_json *queue_member_blo
  		"Paused", mem->paused,
  		"PausedReason", mem->reason_paused,
  		"Ringinuse", mem->ringinuse,
@@ -212,7 +212,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  }
  
  /*! \brief Check if members are available
-@@ -2422,7 +2553,7 @@ static struct ast_json *queue_member_blo
+@@ -2427,7 +2558,7 @@ static struct ast_json *queue_member_blo
   * is available, the function immediately returns 0. If no members are available,
   * then -1 is returned.
   */
@@ -221,7 +221,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  {
  	struct member *member;
  	struct ao2_iterator mem_iter;
-@@ -2442,6 +2573,11 @@ static int get_member_status(struct call
+@@ -2447,6 +2578,11 @@ static int get_member_status(struct call
  			}
  		}
  
@@ -233,7 +233,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		switch (devstate ? ast_device_state(member->state_interface) : member->status) {
  		case AST_DEVICE_INVALID:
  			if (conditions & QUEUE_EMPTY_INVALID) {
-@@ -2500,7 +2636,7 @@ static int get_member_status(struct call
+@@ -2505,7 +2641,7 @@ static int get_member_status(struct call
  
  	if (!devstate && (conditions & QUEUE_EMPTY_RINGING)) {
  		/* member state still may be RINGING due to lag in event message - check again with device state */
@@ -242,7 +242,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	}
  	return -1;
  }
-@@ -2596,6 +2732,7 @@ static void update_status(struct call_qu
+@@ -2601,6 +2737,7 @@ static void update_status(struct call_qu
  		 */
  		pending_members_remove(m);
  
@@ -250,7 +250,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		queue_publish_member_blob(queue_member_status_type(), queue_member_blob_create(q, m));
  	}
  }
-@@ -2606,7 +2743,7 @@ static void update_status(struct call_qu
+@@ -2611,7 +2748,7 @@ static void update_status(struct call_qu
   * \retval 1 if the member is available
   * \retval 0 if the member is not available
   */
@@ -259,7 +259,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  {
  	int available = 0;
  	int wrapuptime;
-@@ -2626,7 +2763,8 @@ static int is_member_available(struct ca
+@@ -2631,7 +2768,8 @@ static int is_member_available(struct ca
  			/* else fall through */
  		case AST_DEVICE_NOT_INUSE:
  		case AST_DEVICE_UNKNOWN:
@@ -269,7 +269,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  				available = 1;
  			}
  			break;
-@@ -2687,7 +2825,7 @@ static void device_state_cb(void *unused
+@@ -2692,7 +2830,7 @@ static void device_state_cb(void *unused
  
  			/* check every member until we find one NOT_INUSE */
  			if (!avail) {
@@ -278,7 +278,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			}
  			if (avail && found_member) {
  				/* early exit as we've found an available member and the member of interest */
-@@ -2865,7 +3003,7 @@ static void destroy_queue_member_cb(void
+@@ -2870,7 +3008,7 @@ static void destroy_queue_member_cb(void
  }
  
  /*! \brief allocate space for new queue member and set fields based on parameters passed */
@@ -287,7 +287,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  {
  	struct member *cur;
  
-@@ -2904,6 +3042,10 @@ static struct member *create_queue_membe
+@@ -2909,6 +3047,10 @@ static struct member *create_queue_membe
  			cur->state_id = -1;
  		}
  		cur->status = get_queue_member_status(cur);
@@ -298,7 +298,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	}
  
  	return cur;
-@@ -3599,6 +3741,7 @@ static void rt_handle_member_record(stru
+@@ -3604,6 +3746,7 @@ static void rt_handle_member_record(stru
  	const char *paused_str = ast_variable_retrieve(member_config, category, "paused");
  	const char *wrapuptime_str = ast_variable_retrieve(member_config, category, "wrapuptime");
  	const char *reason_paused = ast_variable_retrieve(member_config, category, "reason_paused");
@@ -306,7 +306,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  
  	if (ast_strlen_zero(rt_uniqueid)) {
  		ast_log(LOG_WARNING, "Realtime field 'uniqueid' is empty for member %s\n",
-@@ -3663,6 +3806,11 @@ static void rt_handle_member_record(stru
+@@ -3668,6 +3811,11 @@ static void rt_handle_member_record(stru
  				ast_copy_string(m->state_interface, state_interface, sizeof(m->state_interface));
  			}
  			m->penalty = penalty;
@@ -318,7 +318,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			m->ringinuse = ringinuse;
  			m->wrapuptime = wrapuptime;
  			if (realtime_reason_paused) {
-@@ -3670,6 +3818,7 @@ static void rt_handle_member_record(stru
+@@ -3675,6 +3823,7 @@ static void rt_handle_member_record(stru
  			}
  			found = 1;
  			ao2_ref(m, -1);
@@ -326,7 +326,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			break;
  		}
  		ao2_ref(m, -1);
-@@ -3678,9 +3827,10 @@ static void rt_handle_member_record(stru
+@@ -3683,9 +3832,10 @@ static void rt_handle_member_record(stru
  
  	/* Create a new member */
  	if (!found) {
@@ -338,7 +338,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			ast_copy_string(m->rt_uniqueid, rt_uniqueid, sizeof(m->rt_uniqueid));
  			if (!ast_strlen_zero(reason_paused)) {
  				ast_copy_string(m->reason_paused, reason_paused, sizeof(m->reason_paused));
-@@ -3727,6 +3877,10 @@ static void destroy_queue(void *obj)
+@@ -3732,6 +3882,10 @@ static void destroy_queue(void *obj)
  		}
  	}
  	ao2_ref(q->members, -1);
@@ -349,7 +349,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  }
  
  static struct call_queue *alloc_queue(const char *queuename)
-@@ -4061,6 +4215,34 @@ static void update_realtime_members(stru
+@@ -4066,6 +4220,34 @@ static void update_realtime_members(stru
  	ast_config_destroy(member_config);
  }
  
@@ -384,7 +384,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  static int join_queue(char *queuename, struct queue_ent *qe, enum queue_result *reason, int position)
  {
  	struct call_queue *q;
-@@ -4077,7 +4259,7 @@ static int join_queue(char *queuename, s
+@@ -4082,7 +4264,7 @@ static int join_queue(char *queuename, s
  	/* This is our one */
  	if (q->joinempty) {
  		int status = 0;
@@ -393,7 +393,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			*reason = QUEUE_JOINEMPTY;
  			ao2_unlock(q);
  			queue_t_unref(q, "Done with realtime queue");
-@@ -4094,6 +4276,10 @@ static int join_queue(char *queuename, s
+@@ -4099,6 +4281,10 @@ static int join_queue(char *queuename, s
  		 * Take into account the priority of the calling user */
  		inserted = 0;
  		prev = NULL;
@@ -404,7 +404,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		cur = q->head;
  		while (cur) {
  			/* We have higher priority than the current user, enter
-@@ -4126,6 +4312,7 @@ static int join_queue(char *queuename, s
+@@ -4131,6 +4317,7 @@ static int join_queue(char *queuename, s
  		ast_copy_string(qe->announce, q->announce, sizeof(qe->announce));
  		ast_copy_string(qe->context, q->context, sizeof(qe->context));
  		q->count++;
@@ -412,7 +412,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		if (q->count == 1) {
  			ast_devstate_changed(AST_DEVICE_RINGING, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  		}
-@@ -4211,7 +4398,7 @@ static int valid_exit(struct queue_ent *
+@@ -4216,7 +4403,7 @@ static int valid_exit(struct queue_ent *
  
  static int say_position(struct queue_ent *qe, int ringing)
  {
@@ -421,7 +421,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	long avgholdmins, avgholdsecs;
  	time_t now;
  
-@@ -4268,11 +4455,12 @@ static int say_position(struct queue_ent
+@@ -4273,11 +4460,12 @@ static int say_position(struct queue_ent
  		}
  	}
  	/* Round hold time to nearest minute */
@@ -436,7 +436,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		avgholdsecs *= qe->parent->roundingseconds;
  	} else {
  		avgholdsecs = 0;
-@@ -4393,6 +4581,8 @@ static void leave_queue(struct queue_ent
+@@ -4398,6 +4586,8 @@ static void leave_queue(struct queue_ent
  			RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
  			char posstr[20];
  			q->count--;
@@ -445,7 +445,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			if (!q->count) {
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  			}
-@@ -4509,9 +4699,10 @@ static void hangupcalls(struct queue_ent
+@@ -4514,9 +4704,10 @@ static void hangupcalls(struct queue_ent
   * \note The queue passed in should be locked prior to this function call
   *
   * \param[in] q The queue for which we are counting the number of available members
@@ -457,7 +457,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  {
  	struct member *mem;
  	int avl = 0;
-@@ -4520,7 +4711,7 @@ static int num_available_members(struct
+@@ -4525,7 +4716,7 @@ static int num_available_members(struct
  	mem_iter = ao2_iterator_init(q->members, 0);
  	while ((mem = ao2_iterator_next(&mem_iter))) {
  
@@ -466,7 +466,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		ao2_ref(mem, -1);
  
  		/* If autofill is not enabled or if the queue's strategy is ringall, then
-@@ -4561,7 +4752,7 @@ static int compare_weight(struct call_qu
+@@ -4566,7 +4757,7 @@ static int compare_weight(struct call_qu
  		if (q->count && q->members) {
  			if ((mem = ao2_find(q->members, member, OBJ_POINTER))) {
  				ast_debug(1, "Found matching member %s in queue '%s'\n", mem->interface, q->name);
@@ -475,7 +475,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  					ast_debug(1, "Queue '%s' (weight %d, calls %d) is preferred over '%s' (weight %d, calls %d)\n", q->name, q->weight, q->count, rq->name, rq->weight, rq->count);
  					found = 1;
  				}
-@@ -4659,7 +4850,7 @@ static int member_status_available(int s
+@@ -4664,7 +4855,7 @@ static int member_status_available(int s
   *
   * \retval non-zero if an entry can be called.
   */
@@ -484,7 +484,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  {
  	struct member *memberp = call->member;
  	int wrapuptime;
-@@ -4686,6 +4877,13 @@ static int can_ring_entry(struct queue_e
+@@ -4691,6 +4882,13 @@ static int can_ring_entry(struct queue_e
  		return 0;
  	}
  
@@ -498,7 +498,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	if (use_weight && compare_weight(qe->parent, memberp)) {
  		ast_debug(1, "Priority queue delaying call to %s:%s\n",
  			qe->parent->name, call->interface);
-@@ -4766,7 +4964,7 @@ static int ring_entry(struct queue_ent *
+@@ -4771,7 +4969,7 @@ static int ring_entry(struct queue_ent *
  	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
  
  	/* on entry here, we know that tmp->chan == NULL */
@@ -507,7 +507,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		tmp->stillgoing = 0;
  		++*busies;
  		return 0;
-@@ -5774,14 +5972,14 @@ static int is_our_turn(struct queue_ent
+@@ -5779,14 +5977,14 @@ static int is_our_turn(struct queue_ent
  	/* This needs a lock. How many members are available to be served? */
  	ao2_lock(qe->parent);
  
@@ -524,7 +524,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			idx++;
  		}
  		ch = ch->next;
-@@ -5931,7 +6129,7 @@ static int wait_our_turn(struct queue_en
+@@ -5936,7 +6134,7 @@ static int wait_our_turn(struct queue_en
  		if (qe->parent->leavewhenempty) {
  			int status = 0;
  
@@ -533,7 +533,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  				record_abandoned(qe);
  				*reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(qe->parent->name, ast_channel_uniqueid(qe->chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe->pos, qe->opos, (long) (time(NULL) - qe->start));
-@@ -5983,6 +6181,13 @@ static int wait_our_turn(struct queue_en
+@@ -5988,6 +6186,13 @@ static int wait_our_turn(struct queue_en
  			*reason = QUEUE_TIMEOUT;
  			break;
  		}
@@ -547,7 +547,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	}
  
  	return res;
-@@ -7221,6 +7426,7 @@ static int try_calling(struct queue_ent
+@@ -7226,6 +7431,7 @@ static int try_calling(struct queue_ent
  		ao2_unlock(qe->parent);
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
@@ -555,7 +555,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		hangupcalls(qe, outgoing, peer, qe->cancel_answered_elsewhere);
  		outgoing = NULL;
  		if (announce || qe->parent->reportholdtime || qe->parent->memberdelay) {
-@@ -7547,7 +7753,7 @@ static struct member *interface_exists(s
+@@ -7552,7 +7758,7 @@ static struct member *interface_exists(s
  
  /*! \brief Dump all members in a specific queue to the database
   * \code
@@ -564,7 +564,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
   * \endcode
   */
  static void dump_queue_members(struct call_queue *pm_queue)
-@@ -7573,13 +7779,14 @@ static void dump_queue_members(struct ca
+@@ -7578,13 +7784,14 @@ static void dump_queue_members(struct ca
  			continue;
  		}
  
@@ -580,7 +580,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			cur_member->reason_paused,
  			cur_member->wrapuptime);
  
-@@ -7611,6 +7818,7 @@ static int remove_from_queue(const char
+@@ -7616,6 +7823,7 @@ static int remove_from_queue(const char
  		.name = queuename,
  	};
  	struct member *mem, tmpmem;
@@ -588,7 +588,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	int res = RES_NOSUCHQUEUE;
  
  	ast_copy_string(tmpmem.interface, interface, sizeof(tmpmem.interface));
-@@ -7630,13 +7838,20 @@ static int remove_from_queue(const char
+@@ -7635,13 +7843,20 @@ static int remove_from_queue(const char
  			queue_publish_member_blob(queue_member_removed_type(), queue_member_blob_create(q, mem));
  
  			member_remove_from_queue(q, mem);
@@ -610,7 +610,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -7658,7 +7873,7 @@ static int remove_from_queue(const char
+@@ -7663,7 +7878,7 @@ static int remove_from_queue(const char
   * \retval RES_EXISTS queue exists but no members
   * \retval RES_OUT_OF_MEMORY queue exists but not enough memory to create member
  */
@@ -619,7 +619,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  {
  	struct call_queue *q;
  	struct member *new_member, *old_member;
-@@ -7672,15 +7887,16 @@ static int add_to_queue(const char *queu
+@@ -7677,15 +7892,16 @@ static int add_to_queue(const char *queu
  
  	ao2_lock(q);
  	if ((old_member = interface_exists(q, interface)) == NULL) {
@@ -638,7 +638,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -7845,16 +8061,17 @@ static void set_queue_member_pause(struc
+@@ -7893,16 +8109,17 @@ static void set_queue_member_pause(struc
  		dump_queue_members(q);
  	}
  
@@ -658,7 +658,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  
  	publish_queue_member_pause(q, mem);
  }
-@@ -8114,6 +8331,7 @@ static void reload_queue_members(void)
+@@ -8162,6 +8379,7 @@ static void reload_queue_members(void)
  	char *member;
  	char *interface;
  	char *membername = NULL;
@@ -666,7 +666,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	char *state_interface;
  	char *penalty_tok;
  	int penalty = 0;
-@@ -8168,6 +8386,7 @@ static void reload_queue_members(void)
+@@ -8216,6 +8434,7 @@ static void reload_queue_members(void)
  			paused_tok = strsep(&member, ";");
  			membername = strsep(&member, ";");
  			state_interface = strsep(&member, ";");
@@ -674,7 +674,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			reason_paused = strsep(&member, ";");
  			wrapuptime_tok = strsep(&member, ";");
  
-@@ -8202,7 +8421,7 @@ static void reload_queue_members(void)
+@@ -8250,7 +8469,7 @@ static void reload_queue_members(void)
  			ast_debug(1, "Reload Members: Queue: %s  Member: %s  Name: %s  Penalty: %d  Paused: %d ReasonPause: %s  Wrapuptime: %d\n",
  			              queue_name, interface, membername, penalty, paused, reason_paused, wrapuptime);
  
@@ -683,7 +683,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  				ast_log(LOG_ERROR, "Out of Memory when reloading persistent queue member\n");
  				break;
  			}
-@@ -8373,12 +8592,13 @@ static int aqm_exec(struct ast_channel *
+@@ -8421,12 +8640,13 @@ static int aqm_exec(struct ast_channel *
  		AST_APP_ARG(membername);
  		AST_APP_ARG(state_interface);
  		AST_APP_ARG(wrapuptime);
@@ -698,7 +698,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8412,7 +8632,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8460,7 +8680,7 @@ static int aqm_exec(struct ast_channel *
  		wrapuptime = 0;
  	}
  
@@ -707,7 +707,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(args.membername) || !log_membername_as_agent) {
  			ast_queue_log(args.queuename, ast_channel_uniqueid(chan), args.interface, "ADDMEMBER", "%s", "");
-@@ -8548,6 +8768,7 @@ static int queue_exec(struct ast_channel
+@@ -8596,6 +8816,7 @@ static int queue_exec(struct ast_channel
  		AST_APP_ARG(gosub);
  		AST_APP_ARG(rule);
  		AST_APP_ARG(position);
@@ -715,7 +715,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	);
  	/* Our queue entry */
  	struct queue_ent qe = { 0 };
-@@ -8556,7 +8777,7 @@ static int queue_exec(struct ast_channel
+@@ -8604,7 +8825,7 @@ static int queue_exec(struct ast_channel
  	int max_forwards;
  
  	if (ast_strlen_zero(data)) {
@@ -724,7 +724,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8683,6 +8904,9 @@ static int queue_exec(struct ast_channel
+@@ -8731,6 +8952,9 @@ static int queue_exec(struct ast_channel
  	qe.max_penalty = max_penalty;
  	qe.min_penalty = min_penalty;
  	qe.raise_penalty = raise_penalty;
@@ -734,7 +734,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	qe.last_pos_said = 0;
  	qe.last_pos = 0;
  	qe.last_periodic_announce_time = time(NULL);
-@@ -8729,6 +8953,18 @@ check_turns:
+@@ -8777,6 +9001,18 @@ check_turns:
  		ast_moh_start(chan, qe.moh, NULL);
  	}
  
@@ -753,7 +753,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	/* This is the wait loop for callers 2 through maxlen */
  	res = wait_our_turn(&qe, ringing, &reason);
  	if (res) {
-@@ -8807,7 +9043,7 @@ check_turns:
+@@ -8855,7 +9091,7 @@ check_turns:
  
  		if (qe.parent->leavewhenempty) {
  			int status = 0;
@@ -762,7 +762,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  				record_abandoned(&qe);
  				reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(args.queuename, ast_channel_uniqueid(chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe.pos, qe.opos, (long)(time(NULL) - qe.start));
-@@ -8909,6 +9145,16 @@ stop:
+@@ -8957,6 +9193,16 @@ stop:
  	if (reason != QUEUE_UNKNOWN)
  		set_queue_result(chan, reason);
  
@@ -779,7 +779,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	/*
  	 * every queue_ent is given a reference to it's parent
  	 * call_queue when it joins the queue.  This ref must be taken
-@@ -9582,6 +9828,7 @@ static void queue_reset_global_params(vo
+@@ -9630,6 +9876,7 @@ static void queue_reset_global_params(vo
  	force_longest_waiting_caller = 0;
  }
  
@@ -787,7 +787,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  /*! Set the global queue parameters as defined in the "general" section of queues.conf */
  static void queue_set_global_params(struct ast_config *cfg)
  {
-@@ -9620,7 +9867,7 @@ static void queue_set_global_params(stru
+@@ -9668,7 +9915,7 @@ static void queue_set_global_params(stru
   */
  static void reload_single_member(const char *memberdata, struct call_queue *q)
  {
@@ -796,7 +796,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	char *parse;
  	struct member *cur, *newm;
  	struct member tmpmem;
-@@ -9634,6 +9881,7 @@ static void reload_single_member(const c
+@@ -9682,6 +9929,7 @@ static void reload_single_member(const c
  		AST_APP_ARG(state_interface);
  		AST_APP_ARG(ringinuse);
  		AST_APP_ARG(wrapuptime);
@@ -804,7 +804,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	);
  
  	if (ast_strlen_zero(memberdata)) {
-@@ -9688,6 +9936,10 @@ static void reload_single_member(const c
+@@ -9736,6 +9984,10 @@ static void reload_single_member(const c
  		ringinuse = q->ringinuse;
  	}
  
@@ -815,7 +815,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	if (!ast_strlen_zero(args.wrapuptime)) {
  		tmp = args.wrapuptime;
  		ast_strip(tmp);
-@@ -9703,7 +9955,7 @@ static void reload_single_member(const c
+@@ -9751,7 +10003,7 @@ static void reload_single_member(const c
  	ast_copy_string(tmpmem.interface, interface, sizeof(tmpmem.interface));
  	cur = ao2_find(q->members, &tmpmem, OBJ_POINTER);
  
@@ -824,7 +824,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		newm->wrapuptime = wrapuptime;
  		if (cur) {
  			ao2_lock(q->members);
-@@ -9723,6 +9975,7 @@ static void reload_single_member(const c
+@@ -9771,6 +10023,7 @@ static void reload_single_member(const c
  		ao2_ref(newm, -1);
  	}
  	newm = NULL;
@@ -832,7 +832,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  
  	if (cur) {
  		ao2_ref(cur, -1);
-@@ -10011,6 +10264,12 @@ static int reload_handler(int reload, st
+@@ -10059,6 +10312,12 @@ static int reload_handler(int reload, st
  	if (ast_test_flag(mask, QUEUE_RELOAD_RULES)) {
  		res |= reload_queue_rules(reload);
  	}
@@ -845,7 +845,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	if (ast_test_flag(mask, QUEUE_RESET_STATS)) {
  		res |= clear_stats(queuename);
  	}
-@@ -10099,6 +10358,8 @@ static void print_queue(struct mansessio
+@@ -10147,6 +10406,8 @@ static void print_queue(struct mansessio
  					mem->status == AST_DEVICE_UNAVAILABLE || mem->status == AST_DEVICE_UNKNOWN ?
  						COLOR_RED : COLOR_GREEN, COLOR_BLACK),
  					ast_devstate2str(mem->status), ast_term_reset());
@@ -854,7 +854,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			if (mem->calls) {
  				ast_str_append(&out, 0, " has taken %d calls (last was %ld secs ago)",
  					mem->calls, (long) (now - mem->lastcall));
-@@ -10120,8 +10381,32 @@ static void print_queue(struct mansessio
+@@ -10168,8 +10429,32 @@ static void print_queue(struct mansessio
  		struct queue_ent *qe;
  		int pos = 1;
  
@@ -887,7 +887,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  			ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
  				pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
  				(long) (now - qe->start) % 60, qe->prio);
-@@ -10571,11 +10856,12 @@ static int manager_queues_status(struct
+@@ -10619,11 +10904,12 @@ static int manager_queues_status(struct
  						"Paused: %d\r\n"
  						"PausedReason: %s\r\n"
  						"Wrapuptime: %d\r\n"
@@ -901,7 +901,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  					++q_items;
  				}
  				ao2_ref(mem, -1);
-@@ -10620,7 +10906,7 @@ static int manager_queues_status(struct
+@@ -10668,7 +10954,7 @@ static int manager_queues_status(struct
  
  static int manager_add_queue_member(struct mansession *s, const struct message *m)
  {
@@ -910,7 +910,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	int paused, penalty, wrapuptime = 0;
  
  	queuename = astman_get_header(m, "Queue");
-@@ -10630,6 +10916,7 @@ static int manager_add_queue_member(stru
+@@ -10678,6 +10964,7 @@ static int manager_add_queue_member(stru
  	membername = astman_get_header(m, "MemberName");
  	state_interface = astman_get_header(m, "StateInterface");
  	wrapuptime_s = astman_get_header(m, "Wrapuptime");
@@ -918,7 +918,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  
  	if (ast_strlen_zero(queuename)) {
  		astman_send_error(s, m, "'Queue' not specified.");
-@@ -10659,7 +10946,7 @@ static int manager_add_queue_member(stru
+@@ -10707,7 +10994,7 @@ static int manager_add_queue_member(stru
  		paused = abs(ast_true(paused_s));
  	}
  
@@ -927,7 +927,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "MANAGER", interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -10790,6 +11077,14 @@ static int manager_queue_reload(struct m
+@@ -10838,6 +11125,14 @@ static int manager_queue_reload(struct m
  		ast_set_flag(&mask, QUEUE_RELOAD_RULES);
  		header_found = 1;
  	}
@@ -942,7 +942,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	if (!strcasecmp(S_OR(astman_get_header(m, "Parameters"), ""), "yes")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
  		header_found = 1;
-@@ -10994,7 +11289,7 @@ static int manager_request_withdraw_call
+@@ -11047,7 +11342,7 @@ static int manager_request_withdraw_call
  
  static char *handle_queue_add_member(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
  {
@@ -951,7 +951,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	int penalty;
  
  	switch ( cmd ) {
-@@ -11008,7 +11303,7 @@ static char *handle_queue_add_member(str
+@@ -11061,7 +11356,7 @@ static char *handle_queue_add_member(str
  		return complete_queue_add_member(a->line, a->word, a->pos, a->n);
  	}
  
@@ -960,7 +960,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  		return CLI_SHOWUSAGE;
  	} else if (strcmp(a->argv[4], "to")) {
  		return CLI_SHOWUSAGE;
-@@ -11018,6 +11313,8 @@ static char *handle_queue_add_member(str
+@@ -11071,6 +11366,8 @@ static char *handle_queue_add_member(str
  		return CLI_SHOWUSAGE;
  	} else if ((a->argc == 12) && strcmp(a->argv[10], "state_interface")) {
  		return CLI_SHOWUSAGE;
@@ -969,7 +969,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	}
  
  	queuename = a->argv[5];
-@@ -11044,7 +11341,11 @@ static char *handle_queue_add_member(str
+@@ -11097,7 +11394,11 @@ static char *handle_queue_add_member(str
  		state_interface = a->argv[11];
  	}
  
@@ -982,7 +982,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "CLI", interface, "ADDMEMBER", "%s", "");
-@@ -11569,6 +11870,10 @@ static char *handle_queue_reload(struct
+@@ -11627,6 +11928,10 @@ static char *handle_queue_reload(struct
  		ast_set_flag(&mask, QUEUE_RELOAD_MEMBER);
  	} else if (!strcasecmp(a->argv[2], "parameters")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
@@ -993,7 +993,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  	} else if (!strcasecmp(a->argv[2], "all")) {
  		ast_set_flag(&mask, AST_FLAGS_ALL & ~QUEUE_RESET_STATS);
  	}
-@@ -11665,6 +11970,1182 @@ static int qupd_exec(struct ast_channel
+@@ -11723,6 +12028,1182 @@ static int qupd_exec(struct ast_channel
  	return 0;
  }
  
@@ -2176,7 +2176,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  static struct ast_cli_entry cli_queue[] = {
  	AST_CLI_DEFINE(queue_show, "Show status of a specified queue"),
  	AST_CLI_DEFINE(handle_queue_rule_show, "Show the rules defined in queuerules.conf"),
-@@ -11676,11 +13157,10 @@ static struct ast_cli_entry cli_queue[]
+@@ -11734,11 +13215,10 @@ static struct ast_cli_entry cli_queue[]
  	AST_CLI_DEFINE(handle_queue_reload, "Reload queues, members, queue rules, or parameters"),
  	AST_CLI_DEFINE(handle_queue_reset, "Reset statistics for a queue"),
  	AST_CLI_DEFINE(handle_queue_change_priority_caller, "Change priority caller on queue"),
@@ -2190,7 +2190,7 @@ Index: asterisk-20.4.0/apps/app_queue.c
  static int unload_module(void)
  {
  	stasis_message_router_unsubscribe_and_join(agent_router);
-@@ -11912,32 +13392,6 @@ static int load_module(void)
+@@ -11970,32 +13450,6 @@ static int load_module(void)
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -2223,10 +2223,10 @@ Index: asterisk-20.4.0/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-20.4.0/configs/samples/queueskillrules.conf.sample
+Index: asterisk-20.5.0/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-20.4.0/configs/samples/queueskillrules.conf.sample
++++ asterisk-20.5.0/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2291,10 +2291,10 @@ Index: asterisk-20.4.0/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-20.4.0/configs/samples/queueskills.conf.sample
+Index: asterisk-20.5.0/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-20.4.0/configs/samples/queueskills.conf.sample
++++ asterisk-20.5.0/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
no patch modification done, only line number changes

Depends-On: https://github.com/wazo-platform/asterisk-vanilla/pull/5

I added asterisk-vanilla as a dependency to get it merged first and avoid incrementing the version numbers for the sake of rebuilding if we are doing it in reverse order.