### PR TITLE
use libsrtp2 (from debian) instead libsrtp0 (from wazo)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:20.5.0-1~wazo5) wazo-dev-bullseye; urgency=medium
+
+  * use libsrtp2
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Fri, 03 Nov 2023 14:04:06 -0400
+
 asterisk (8:20.5.0-1~wazo3) wazo-dev-bullseye; urgency=medium
 
   * force rebuild for asterisk-vanilla

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Build-Depends:
  libspeex-dev,
  libspeexdsp-dev,
  libsqlite3-dev,
- libsrtp0-dev (>= 1.5.4),
+ libsrtp2-dev,
  libssl-dev,
  libunbound-dev,
  liburiparser-dev,


### PR DESCRIPTION
why: because libsrtp2 is maintain by debian team and do not require to
maintain an old debian packaging system that will be unavailable in next
debian versions

see WAZO-3487