### PR TITLE
use TCMalloc memory allocator

### DIFF
--- a/debian/asterisk.service
+++ b/debian/asterisk.service
@@ -6,6 +6,7 @@ Before=monit.service
 
 [Service]
 Type=forking
+Environment=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
 ExecStartPre=install -d -o asterisk -g asterisk /run/asterisk
 ExecStartPre=install -d -o asterisk -g asterisk /var/log/asterisk
 ExecStartPre=install -d -o asterisk -g asterisk /var/log/asterisk/cdr-csv

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:21.1.0-1~wazo4) wazo-dev-bullseye; urgency=medium
+
+  * switch to TCMalloc memory allocator
+
+ -- Wazo Maintainers <dev@wazo.community>  Thu, 30 May 2024 11:33:08 -0400
+
 asterisk (8:21.1.0-1~wazo3) wazo-dev-bullseye; urgency=medium
 
   * update copyright file

--- a/debian/control
+++ b/debian/control
@@ -31,6 +31,7 @@ Build-Depends:
  libsqlite3-dev,
  libsrtp2-dev,
  libssl-dev,
+ libtcmalloc-minimal4,
  libunbound-dev,
  liburiparser-dev,
  libvorbis-dev,


### PR DESCRIPTION
Why:

* Reduces memory usage for long-running processes