### PR TITLE
[WAZO-3723] Add more directory permissions to the packaging

### DIFF
--- a/debian/asterisk.postinst
+++ b/debian/asterisk.postinst
@@ -90,8 +90,15 @@ case "$1" in
 	done
 
     # WAZO: Do a more aggressive chmod/chown on asterisk files
-    asterisk_dirs="/etc/asterisk /var/lib/asterisk /var/spool/asterisk/monitor"
+    asterisk_dirs="/etc/asterisk /var/lib/asterisk /var/spool/asterisk/monitor /var/lib/asterisk/moh /var/lib/asterisk/sounds/custom /usr/share/asterisk/moh /var/spool/asterisk/fax"
+    # NOTE(afournier): originally missing dirs:
+    # /var/lib/asterisk/moh
+    # /var/lib/asterisk/sounds/custom
+    # /usr/share/asterisk/moh
+    # /var/spool/asterisk/fax
 
+    # NOTE(afournier): the user:group was overridden for asterisk:www-data by the xivo-fix-paths-rights script
+    # However, the asterisk user is a member of the www-data group so that does not change a lot
     chown -R asterisk:asterisk $asterisk_dirs
     for dir in $asterisk_dirs; do
         find $dir -type d -exec chmod 2775 {} \;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:21.4.1-1~wazo3) wazo-dev-bullseye; urgency=medium
+
+  * fix more directories permissions on postinst script
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 01 Oct 2024 09:56:40 -0400
+
 asterisk (8:21.4.1-1~wazo2) wazo-dev-bullseye; urgency=medium
 
   * Asterisk 21.4.1


### PR DESCRIPTION
Why: by removing the xivo-fix-paths-rights script, we need to chown more directories that were chown'ed by the script.