### PR TITLE
Wazo 4031 mixmonitor announce file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.1.1-1~wazo3) wazo-dev-bullseye; urgency=medium
+
+  * change beep sound
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 04 Feb 2025 14:04:38 -0500
+
 asterisk (8:22.1.1-1~wazo2) wazo-dev-bullseye; urgency=medium
 
   * Asterisk 22.1.1

--- a/debian/patches/mix_monitor_announce_file
+++ b/debian/patches/mix_monitor_announce_file
@@ -1,0 +1,22 @@
+Index: asterisk-22.1.1/apps/app_mixmonitor.c
+===================================================================
+--- asterisk-22.1.1.orig/apps/app_mixmonitor.c
++++ asterisk-22.1.1/apps/app_mixmonitor.c
+@@ -870,7 +870,7 @@ static void *mixmonitor_thread(void *obj
+ 
+ 	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {
+ 		ast_autochan_channel_lock(mixmonitor->autochan);
+-		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "")) {
++		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "/usr/share/asterisk/sounds/fr_FR/record-call-off", "")) {
+ 			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
+ 		}
+ 		ast_autochan_channel_unlock(mixmonitor->autochan);
+@@ -963,7 +963,7 @@ static int setup_mixmonitor_ds(struct mi
+ 
+ 	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_START)) {
+ 		ast_autochan_channel_lock(mixmonitor->autochan);
+-		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "")) {
++		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "/usr/share/asterisk/sounds/fr_FR/record-call-on", "")) {
+ 			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
+ 		}
+ 		ast_autochan_channel_unlock(mixmonitor->autochan);

--- a/debian/patches/mix_monitor_announce_file
+++ b/debian/patches/mix_monitor_announce_file
@@ -2,21 +2,136 @@ Index: asterisk-22.1.1/apps/app_mixmonitor.c
 ===================================================================
 --- asterisk-22.1.1.orig/apps/app_mixmonitor.c
 +++ asterisk-22.1.1/apps/app_mixmonitor.c
-@@ -870,7 +870,7 @@ static void *mixmonitor_thread(void *obj
+@@ -142,10 +142,14 @@
+ 						<para>Stores the MixMonitor's ID on this channel variable.</para>
+ 					</option>
+ 					<option name="p">
+-						<para>Play a beep on the channel that starts the recording.</para>
++						<argument name="sound" required="false" />
++						<para>Play a sound on the channel that starts the recording. If the sound is not specified,
++						"beep" will be used.</para>
+ 					</option>
+ 					<option name="P">
+-						<para>Play a beep on the channel that stops the recording.</para>
++						<argument name="sound" required="false" />
++						<para>Play a sound on the channel that stops the recording. If the sound is not specified,
++						"beep" will be used.</para>
+ 					</option>
+ 					<option name="m">
+ 						<argument name="mailbox" required="true" />
+@@ -380,6 +384,8 @@ struct mixmonitor {
+ 	char *filename;
+ 	char *filename_read;
+ 	char *filename_write;
++	char *start_sound;
++	char *stop_sound;
+ 	char *post_process;
+ 	char *name;
+ 	ast_callid callid;
+@@ -433,6 +439,8 @@ enum mixmonitor_args {
+ 	OPT_ARG_BEEP_INTERVAL,
+ 	OPT_ARG_DEPRECATED_RWSYNC,
+ 	OPT_ARG_NO_RWSYNC,
++	OPT_ARG_START_SOUND,
++	OPT_ARG_STOP_SOUND,
+ 	OPT_ARG_ARRAY_SIZE,	/* Always last element of the enum */
+ };
+ 
+@@ -442,8 +450,8 @@ AST_APP_OPTIONS(mixmonitor_opts, {
+ 	AST_APP_OPTION_ARG('B', MUXFLAG_BEEP, OPT_ARG_BEEP_INTERVAL),
+ 	AST_APP_OPTION('c', MUXFLAG_REAL_CALLERID),
+ 	AST_APP_OPTION('d', MUXFLAG_AUTO_DELETE),
+-	AST_APP_OPTION('p', MUXFLAG_BEEP_START),
+-	AST_APP_OPTION('P', MUXFLAG_BEEP_STOP),
++	AST_APP_OPTION_ARG('p', MUXFLAG_BEEP_START, OPT_ARG_START_SOUND),
++	AST_APP_OPTION_ARG('P', MUXFLAG_BEEP_STOP, OPT_ARG_STOP_SOUND),
+ 	AST_APP_OPTION_ARG('v', MUXFLAG_READVOLUME, OPT_ARG_READVOLUME),
+ 	AST_APP_OPTION_ARG('V', MUXFLAG_WRITEVOLUME, OPT_ARG_WRITEVOLUME),
+ 	AST_APP_OPTION_ARG('W', MUXFLAG_VOLUME, OPT_ARG_VOLUME),
+@@ -631,6 +639,8 @@ static void mixmonitor_free(struct mixmo
+ 		ast_free(mixmonitor->filename);
+ 		ast_free(mixmonitor->filename_write);
+ 		ast_free(mixmonitor->filename_read);
++		ast_free(mixmonitor->start_sound);
++		ast_free(mixmonitor->stop_sound);
+ 
+ 		/* Free everything in the recipient list */
+ 		clear_mixmonitor_recipient_list(mixmonitor);
+@@ -870,7 +880,7 @@ static void *mixmonitor_thread(void *obj
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {
  		ast_autochan_channel_lock(mixmonitor->autochan);
 -		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "")) {
-+		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "/usr/share/asterisk/sounds/fr_FR/record-call-off", "")) {
++		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, mixmonitor->stop_sound, "")) {
  			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
  		}
  		ast_autochan_channel_unlock(mixmonitor->autochan);
-@@ -963,7 +963,7 @@ static int setup_mixmonitor_ds(struct mi
+@@ -963,7 +973,7 @@ static int setup_mixmonitor_ds(struct mi
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_START)) {
  		ast_autochan_channel_lock(mixmonitor->autochan);
 -		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "beep", "")) {
-+		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, "/usr/share/asterisk/sounds/fr_FR/record-call-on", "")) {
++		if (-1 == ast_stream_and_wait(mixmonitor->autochan->chan, mixmonitor->start_sound, "")) {
  			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
  		}
  		ast_autochan_channel_unlock(mixmonitor->autochan);
+@@ -1006,8 +1016,9 @@ static void mixmonitor_ds_remove_and_fre
+ static int launch_monitor_thread(struct ast_channel *chan, const char *filename,
+ 				  unsigned int flags, int readvol, int writevol,
+ 				  const char *post_process, const char *filename_write,
+-				  char *filename_read, const char *uid_channel_var,
+-				  const char *recipients, const char *beep_id)
++				  char *filename_read, const char *start_sound, const char *stop_sound,
++				  const char *uid_channel_var, const char *recipients,
++				  const char *beep_id)
+ {
+ 	pthread_t thread;
+ 	struct mixmonitor *mixmonitor;
+@@ -1068,6 +1079,14 @@ static int launch_monitor_thread(struct
+ 		mixmonitor->filename_read = ast_strdup(filename_read);
+ 	}
+ 
++	if (!ast_strlen_zero(start_sound)) {
++		mixmonitor->start_sound = ast_strdup(start_sound);
++	}
++
++	if (!ast_strlen_zero(stop_sound)) {
++		mixmonitor->stop_sound = ast_strdup(stop_sound);
++	}
++
+ 	if (setup_mixmonitor_ds(mixmonitor, chan, &datastore_id, beep_id)) {
+ 		ast_autochan_destroy(mixmonitor->autochan);
+ 		mixmonitor_free(mixmonitor);
+@@ -1217,6 +1236,8 @@ static int mixmonitor_exec(struct ast_ch
+ 	int x, readvol = 0, writevol = 0;
+ 	char *filename_read = NULL;
+ 	char *filename_write = NULL;
++	char *start_sound = NULL;
++	char *stop_sound = NULL;
+ 	char filename_buffer[1024] = "";
+ 	char *uid_channel_var = NULL;
+ 	char beep_id[64] = "";
+@@ -1295,6 +1316,14 @@ static int mixmonitor_exec(struct ast_ch
+ 			filename_read = ast_strdupa(filename_parse(opts[OPT_ARG_READNAME], filename_buffer, sizeof(filename_buffer)));
+ 		}
+ 
++		if (ast_test_flag(&flags, MUXFLAG_BEEP_START)) {
++			start_sound = S_OR(ast_skip_blanks(opts[OPT_ARG_START_SOUND]), "beep");
++		}
++
++		if (ast_test_flag(&flags, MUXFLAG_BEEP_STOP)) {
++			stop_sound = S_OR(ast_skip_blanks(opts[OPT_ARG_STOP_SOUND]), "beep");
++		}
++
+ 		if (ast_test_flag(&flags, MUXFLAG_UID)) {
+ 			uid_channel_var = opts[OPT_ARG_UID];
+ 		}
+@@ -1338,6 +1367,8 @@ static int mixmonitor_exec(struct ast_ch
+ 			args.post_process,
+ 			filename_write,
+ 			filename_read,
++			start_sound,
++			stop_sound,
+ 			uid_channel_var,
+ 			recipients,
+ 			beep_id)) {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,4 @@ wazo_stun_recurring_resolution
 increase-max-sdp-media
 mixmonitor_close_beep_file
 fix-invalid-moh
+mix_monitor_announce_file


### PR DESCRIPTION
This PR can be tested with a modification to the `/etc/xivo/asterisk/xivo_globals.conf` file with the following values
```
; MixMonitor
WAZO_MIXMONITOR_OPTIONS = p(/usr/share/asterisk/sounds/fr_FR/record-call-on)P(/usr/share/asterisk/sounds/fr_FR/record-call-off)
; WAZO_MIXMONITOR_OPTIONS = p(record-call-on)P(record-call-off)
; WAZO_MIXMONITOR_OPTIONS = pP
```

The `pP` version should play "beep"
Removing the variable should result in no sound on start and stop