### PR TITLE
backport patch from asterisk PR-1136

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.2.0-1~wazo4) wazo-dev-bullseye; urgency=medium
+
+  * backport revert RTP set mark
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 20 Mar 2025 09:12:04 -0400
+
 asterisk (8:22.2.0-1~wazo3) wazo-dev-bullseye; urgency=medium
 
   * Fix stasis application playback event

--- a/debian/patches/asterisk-PR-1136-revert-set-mark-on-rtp
+++ b/debian/patches/asterisk-PR-1136-revert-set-mark-on-rtp
@@ -1,0 +1,30 @@
+commit e02de88e4e1f6ee155421311d7bc8cf7cc69f37a
+Author: Maximilian Fridrich <m.fridrich@commend.com>
+Date:   Fri Feb 28 08:43:44 2025 +0100
+
+    Revert "res_rtp_asterisk.c: Set Mark on rtp when timestamp skew is too big"
+    
+    This reverts commit f30ad96b3f467739c38ff415e80bffc4afff1da7.
+    
+    The original change was not RFC compliant and caused issues because it
+    set the RTP marker bit in cases when it shouldn't be set. See the
+    linked issue #1135 for a detailed explanation.
+    
+    Fixes: #1135.
+
+Index: asterisk-22.2.0/res/res_rtp_asterisk.c
+===================================================================
+--- asterisk-22.2.0.orig/res/res_rtp_asterisk.c
++++ asterisk-22.2.0/res/res_rtp_asterisk.c
+@@ -5268,11 +5268,6 @@ static int rtp_raw_write(struct ast_rtp_
+ 	}
+ 
+ 	if (ast_test_flag(frame, AST_FRFLAG_HAS_TIMING_INFO)) {
+-		if (abs(frame->ts * rate - (int)rtp->lastts) > MAX_TIMESTAMP_SKEW) {
+-			ast_verbose("(%p) RTP audio difference is %d set mark\n",
+-				instance, abs(frame->ts * rate - (int)rtp->lastts));
+-			mark = 1;
+-		}
+ 		rtp->lastts = frame->ts * rate;
+ 	}
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -27,3 +27,4 @@ mixmonitor_close_beep_file
 fix-invalid-moh
 mix_monitor_announce_file
 fix-application-playback-update
+asterisk-PR-1136-revert-set-mark-on-rtp


### PR DESCRIPTION
why: fix video call from regression introduced in 22.2.0