### PR TITLE
WAZO-4326-bookworm

### DIFF
--- a/debian/asterisk-dev.install
+++ b/debian/asterisk-dev.install
@@ -1,2 +1,2 @@
 include/asterisk usr/include/
-include/asterisk.h usr/include/asterisk.h
+include/asterisk.h usr/include/asterisk/

--- a/debian/asterisk-dev.links
+++ b/debian/asterisk-dev.links
@@ -1,0 +1,1 @@
+usr/include/asterisk/asterisk.h		usr/include/asterisk.h


### PR DESCRIPTION
why: fix issue with custom modules (ex: wazo-res-consul-stasis-app)
