### PR TITLE
[ITEM-379] queue-deadlock: fix patch from review

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.9.0-1~wazo4) wazo-dev-bookworm; urgency=medium
+
+  * Fix issues in queue deadlock patch
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 11 Jun 2026 14:18:38 -0400
+
 asterisk (8:22.9.0-1~wazo3) wazo-dev-bookworm; urgency=medium
 
   * add RTP ioqueue thread destroy patch from asterisk upstream

--- a/debian/patches/fix-queue-deadlock
+++ b/debian/patches/fix-queue-deadlock
@@ -102,18 +102,26 @@ Index: asterisk-22.9.0/apps/app_queue.c
  		available = 0;
  	}
  	return available;
-@@ -3234,12 +3258,28 @@ static void destroy_queue_member_cb(void
+@@ -3234,12 +3258,36 @@ static void destroy_queue_member_cb(void
  	if (mem->state_id != -1) {
  		ast_extension_state_del(mem->state_id, extension_state_cb);
  	}
 +	ao2_ref(mem->unique, -1);
 +}
 +
++static void destroy_shared_info_cb(void *obj)
++{
++	struct shared_info *member_shared = obj;
++
++	ao2_cleanup(member_shared->lastqueue);
++	ast_mutex_destroy(&member_shared->lock);
++}
++
 +static struct shared_info *create_shared_info()
 +{
 +	struct shared_info *member_shared = NULL;
 +
-+	if (!(member_shared = ao2_alloc(sizeof(*member_shared), NULL))) {
++	if (!(member_shared = ao2_alloc(sizeof(*member_shared), destroy_shared_info_cb))) {
 +		return NULL;
 +	}
 +	ast_mutex_init(&member_shared->lock);
@@ -132,7 +140,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  
  	if ((cur = ao2_alloc(sizeof(*cur), destroy_queue_member_cb))) {
  		cur->ringinuse = ringinuse;
-@@ -3280,6 +3320,34 @@ static struct member *create_queue_membe
+@@ -3280,6 +3328,34 @@ static struct member *create_queue_membe
  			ast_copy_string(cur->skills, skills, sizeof(cur->skills));
  		else
  			cur->skills[0] = '\0';
@@ -167,7 +175,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  	}
  
  	return cur;
-@@ -3440,10 +3508,10 @@ static void clear_queue(struct call_queu
+@@ -3440,10 +3516,10 @@ static void clear_queue(struct call_queu
  		struct member *mem;
  		struct ao2_iterator mem_iter = ao2_iterator_init(q->members, 0);
  		while ((mem = ao2_iterator_next(&mem_iter))) {
@@ -182,20 +190,21 @@ Index: asterisk-22.9.0/apps/app_queue.c
  			ao2_ref(mem, -1);
  		}
  		ao2_iterator_destroy(&mem_iter);
-@@ -5111,6 +5179,7 @@ static int member_status_available(int s
+@@ -5111,6 +5187,7 @@ static int member_status_available(int s
  static int can_ring_entry(struct queue_ent *qe, struct callattempt *call, int *busies)
  {
  	struct member *memberp = call->member;
-+	struct call_queue *lastqueue =  get_lastqueue(memberp);
++	struct call_queue *lastqueue;
  	int wrapuptime;
  
  	if (memberp->paused) {
-@@ -5123,14 +5192,14 @@ static int can_ring_entry(struct queue_e
+@@ -5123,17 +5200,20 @@ static int can_ring_entry(struct queue_e
  		return 0;
  	}
  
 -	if (memberp->lastqueue) {
 -		wrapuptime = get_wrapuptime(memberp->lastqueue, memberp);
++	lastqueue = get_lastqueue(memberp);
 +	if (lastqueue) {
 +		wrapuptime = get_wrapuptime(lastqueue, memberp);
  	} else {
@@ -207,9 +216,14 @@ Index: asterisk-22.9.0/apps/app_queue.c
 -			(memberp->lastqueue ? memberp->lastqueue->name : qe->parent->name),
 +			(lastqueue ? lastqueue->name : qe->parent->name),
  			call->interface);
++		ao2_cleanup(lastqueue);
  		return 0;
  	}
-@@ -5593,8 +5662,8 @@ static void rna(int rnatime, struct queu
++	ao2_cleanup(lastqueue);
+ 
+ 	if (!member_is_selected(qe, memberp)) {
+ 		ast_debug(1, "%s doesn't match ruleset '%s'\n",
+@@ -5593,8 +5673,8 @@ static void rna(int rnatime, struct queu
  			struct member *mem;
  			ao2_lock(qe->parent);
  			if ((mem = interface_exists(qe->parent, interface))) {
@@ -220,7 +234,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  					ao2_unlock(qe->parent);
  					ao2_ref(mem, -1);
  					return;
-@@ -6434,6 +6503,141 @@ static int wait_our_turn(struct queue_en
+@@ -6434,6 +6514,149 @@ static int wait_our_turn(struct queue_en
  }
  
  /*!
@@ -277,10 +291,14 @@ Index: asterisk-22.9.0/apps/app_queue.c
 +*/
 +static void update_lastqueue(struct member *mem, struct call_queue *val)
 +{
++	struct call_queue *old;
++
 +	mem->lastqueue = val;
 +	ast_mutex_lock(&mem->unique->lock);
-+	mem->unique->lastqueue = val;
++	old = mem->unique->lastqueue;
++	mem->unique->lastqueue = ao2_bump(val);
 +	ast_mutex_unlock(&mem->unique->lock);
++	ao2_cleanup(old);
 +}
 +
 +/*!
@@ -345,15 +363,19 @@ Index: asterisk-22.9.0/apps/app_queue.c
 +
 +/*!
 + * \brief return the lastqueue value of a queue member
-+ * \retval lastqueue value of member. If `shared_lastcall` is enabled, the shared value is returned.
++ * \retval lastqueue value of member, with its reference count incremented.
++ * If `shared_lastcall` is enabled, the shared value is returned.
++ * The caller must release the reference with ao2_cleanup().
 +*/
 +static struct call_queue *get_lastqueue(struct member *mem)
 +{
-+	struct call_queue *lastqueue = mem->lastqueue;
++	struct call_queue *lastqueue;
 +	if (shared_lastcall) {
 +		ast_mutex_lock(&mem->unique->lock);
-+		lastqueue = mem->unique->lastqueue;
++		lastqueue = ao2_bump(mem->unique->lastqueue);
 +		ast_mutex_unlock(&mem->unique->lock);
++	} else {
++		lastqueue = ao2_bump(mem->lastqueue);
 +	}
 +	return lastqueue;
 +}
@@ -362,7 +384,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
   * \brief update the queue status
   * \retval 0 always
  */
-@@ -6441,43 +6645,23 @@ static int update_queue(struct call_queu
+@@ -6441,43 +6664,23 @@ static int update_queue(struct call_queu
  {
  	int oldtalktime;
  	int newtalktime = time(NULL) - starttime;
@@ -415,7 +437,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  	/* Member might never experience any direct status change (local
  	 * channel with forwarding in particular). If that's the case,
  	 * this is the last chance to remove it from pending or subsequent
-@@ -6569,14 +6753,14 @@ static int calc_metric(struct call_queue
+@@ -6569,14 +6772,14 @@ static int calc_metric(struct call_queue
  		tmp->metric = ast_random() % ((1 + penalty) * 1000);
  		break;
  	case QUEUE_STRATEGY_FEWESTCALLS:
@@ -433,7 +455,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  		}
  		tmp->metric += penalty * 1000000 * usepenalty;
  		break;
-@@ -7700,7 +7884,8 @@ static int try_calling(struct queue_ent
+@@ -7700,7 +7903,8 @@ static int try_calling(struct queue_ent
  		recalc_holdtime(qe, (now - qe->start));
  		member = lpeer->member;
  		ao2_lock(qe->parent);
@@ -443,7 +465,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  		ao2_unlock(qe->parent);
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
-@@ -7809,7 +7994,7 @@ static int try_calling(struct queue_ent
+@@ -7809,7 +8013,7 @@ static int try_calling(struct queue_ent
  		/* use  pbx_builtin_setvar to set a load of variables with one call */
  		if (qe->parent->setinterfacevar && interfacevar) {
  			ast_str_set(&interfacevar, 0, "MEMBERINTERFACE=%s,MEMBERNAME=%s,MEMBERCALLS=%d,MEMBERLASTCALL=%ld,MEMBERPENALTY=%d,MEMBERDYNAMIC=%d,MEMBERREALTIME=%d",
@@ -452,7 +474,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  			pbx_builtin_setvar_multiple(qe->chan, ast_str_buffer(interfacevar));
  			pbx_builtin_setvar_multiple(peer, ast_str_buffer(interfacevar));
  		}
-@@ -7936,8 +8121,8 @@ static int try_calling(struct queue_ent
+@@ -7936,8 +8140,8 @@ static int try_calling(struct queue_ent
  		}
  
  		ao2_lock(qe->parent);
@@ -463,7 +485,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  		ao2_unlock(qe->parent);
  		/* As a queue member may end up in multiple calls at once if a transfer occurs with
  		 * a Local channel in the mix we pass the current call information (starttime) to the
-@@ -9697,7 +9882,7 @@ static int queue_function_mem_read(struc
+@@ -9697,7 +9901,7 @@ static int queue_function_mem_read(struc
  			while ((m = ao2_iterator_next(&mem_iter))) {
  				/* Count the agents who are logged in, not paused and not wrapping up */
  				if ((m->status == AST_DEVICE_NOT_INUSE) && (!m->paused) &&
@@ -472,7 +494,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  					count++;
  				}
  				ao2_ref(m, -1);
-@@ -10377,8 +10562,8 @@ static void reload_single_member(const c
+@@ -10377,8 +10581,8 @@ static void reload_single_member(const c
  			/* Round Robin Queue Position must be copied if this is replacing an existing member */
  			newm->queuepos = cur->queuepos;
  			/* Don't reset agent stats either */
@@ -483,16 +505,29 @@ Index: asterisk-22.9.0/apps/app_queue.c
  
  			ao2_link(q->members, newm);
  			ao2_unlink(q->members, cur);
-@@ -10757,7 +10942,7 @@ static void print_queue(struct mansessio
+@@ -10735,10 +10939,12 @@ static void print_queue(struct mansessio
+ 		do_print(s, fd, "   No Members");
+ 	} else {
+ 		struct member *mem;
++		time_t starttime;
+ 
+ 		do_print(s, fd, "   Members: ");
+ 		mem_iter = ao2_iterator_init(q->members, 0);
+ 		while ((mem = ao2_iterator_next(&mem_iter))) {
++			starttime = get_starttime(mem);
+ 			ast_str_set(&out, 0, "      %s", mem->membername);
+ 			if (strcasecmp(mem->membername, mem->interface)) {
+ 				ast_str_append(&out, 0, " (%s", mem->interface);
+@@ -10757,7 +10963,7 @@ static void print_queue(struct mansessio
  			ast_str_append(&out, 0, "%s%s%s%s%s%s%s%s%s",
  				mem->dynamic ? ast_term_color(COLOR_CYAN, COLOR_BLACK) : "", mem->dynamic ? " (dynamic)" : "", ast_term_reset(),
  				mem->realtime ? ast_term_color(COLOR_MAGENTA, COLOR_BLACK) : "", mem->realtime ? " (realtime)" : "", ast_term_reset(),
 -				mem->starttime ? ast_term_color(COLOR_BROWN, COLOR_BLACK) : "", mem->starttime ? " (in call)" : "", ast_term_reset());
-+				mem->starttime ? ast_term_color(COLOR_BROWN, COLOR_BLACK) : "", get_starttime(mem) ? " (in call)" : "", ast_term_reset());
++				starttime ? ast_term_color(COLOR_BROWN, COLOR_BLACK) : "", starttime ? " (in call)" : "", ast_term_reset());
  
  			if (mem->paused) {
  				ast_str_append(&out, 0, " %s(paused%s%s was %ld secs ago)%s",
-@@ -10775,9 +10960,9 @@ static void print_queue(struct mansessio
+@@ -10775,9 +10981,9 @@ static void print_queue(struct mansessio
  					ast_devstate2str(mem->status), ast_term_reset());
  			if (!ast_strlen_zero(mem->skills))
  				ast_str_append(&out, 0, " (skills: %s)", mem->skills);
@@ -504,7 +539,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  			} else {
  				ast_str_append(&out, 0, " has taken no calls yet");
  			}
-@@ -11275,7 +11460,7 @@ static int manager_queues_status(struct
+@@ -11275,7 +11481,7 @@ static int manager_queues_status(struct
  						"%s"
  						"\r\n",
  						q->name, mem->membername, mem->interface, mem->state_interface, mem->dynamic ? "dynamic" : "static",
@@ -513,7 +548,7 @@ Index: asterisk-22.9.0/apps/app_queue.c
  						mem->paused, mem->reason_paused, mem->wrapuptime, mem->skills, idText);
  					++q_items;
  				}
-@@ -12374,17 +12559,16 @@ static int qupd_exec(struct ast_channel
+@@ -12374,17 +12580,16 @@ static int qupd_exec(struct ast_channel
  				if (!strcasecmp(args.status, "ANSWER")) {
  					oldtalktime = q->talktime;
  					q->talktime = (((oldtalktime << 2) - oldtalktime) + newtalktime) >> 2;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core call-queue member locking and reference counting in production Asterisk; regressions could affect wrap-up, routing metrics, or deadlocks under multi-queue agents.
> 
> **Overview**
> Refines the Wazo **`fix-queue-deadlock`** patch for Asterisk `app_queue.c` and bumps the package to **8:22.9.0-1~wazo4** in `debian/changelog`.
> 
> **Shared member state lifecycle:** `shared_info` is now allocated with **`destroy_shared_info_cb`**, which tears down the mutex and **`ao2_cleanup`s** the shared `lastqueue`. **`update_lastqueue`** swaps the shared queue pointer with **`ao2_bump` / `ao2_cleanup`** instead of storing a bare pointer.
> 
> **`get_lastqueue` contract:** Callers receive a **bumped** `call_queue` reference and must release it; **`can_ring_entry`** uses the getter and **`ao2_cleanup(lastqueue)`** on every exit path (including after wrap-up checks).
> 
> **`update_queue`:** The old **`shared_lastcall`** path that walked every queue to update duplicate members is removed; completion stats go through the existing **`update_*` / `get_*`** helpers while holding the current queue lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef9c7c5c619c7543facfc7d4e59e09a1ff9447d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->