### PR TITLE
Jenkins: launch xivo-res-freeze-check job on success

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
     success {
       build wait: false, job: 'asterisk-to-asterisk-vanilla'
       build wait: false, job: 'asterisk-to-asterisk-debug'
+      build wait: false, job: 'xivo-res-freeze-check'
     }
     failure {
       emailext to: "${MAIL_RECIPIENTS}", subject: '${DEFAULT_SUBJECT}', body: '${DEFAULT_CONTENT}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,13 @@ pipeline {
     success {
       build wait: false, job: 'asterisk-to-asterisk-vanilla'
       build wait: false, job: 'asterisk-to-asterisk-debug'
-      build wait: false, job: 'xivo-res-freeze-check'
+      script {
+        if (env.JOB_NAME == 'asterisk.asterisk-rc') {
+          build wait: false, job: 'xivo-res-freeze-check.asterisk-rc'
+        } else {
+          build wait: false, job: 'xivo-res-freeze-check'
+        }
+      }
     }
     failure {
       emailext to: "${MAIL_RECIPIENTS}", subject: '${DEFAULT_SUBJECT}', body: '${DEFAULT_CONTENT}'


### PR DESCRIPTION
Why: res-freeze-check depends on asterisk ABI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Jenkins post-success hook with no application or runtime code changes.
> 
> **Overview**
> On **successful** completion of this Asterisk package pipeline, Jenkins now also kicks off **`xivo-res-freeze-check`** asynchronously (same pattern as the existing `asterisk-to-asterisk-*` downstream jobs).
> 
> The downstream job name depends on **`JOB_NAME`**: builds from **`asterisk.asterisk-rc`** trigger **`xivo-res-freeze-check.asterisk-rc`**, all other jobs trigger **`xivo-res-freeze-check`**. This wires ABI-related freeze checks to run after a fresh Asterisk build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453d0a7c100df6d4fa9e66ab3d9d682e094d13aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->