### PR TITLE
add NULL src dereference format_cap patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.10.0-1~wazo5) wazo-dev-bookworm; urgency=medium
+
+  * add format_cap NULL dereference patch
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 23 Jun 2026 10:16:47 -0400
+
 asterisk (8:22.10.0-1~wazo4) wazo-dev-bookworm; urgency=medium
 
   * asterisk 22.10.0

--- a/debian/patches/null-src-format-cap
+++ b/debian/patches/null-src-format-cap
@@ -1,0 +1,51 @@
+From: Wazo Support <support@wazo.io>
+Date: Tue, 23 Jun 2026 00:00:00 +0000
+Subject: [PATCH] format_cap: guard against NULL src in *_from_cap helpers
+
+ast_format_cap_append_from_cap() and ast_format_cap_replace_from_cap()
+dereference `src` (src->preference_order) without checking it for NULL.
+
+A dummy channel allocated with ast_dummy_channel_alloc() never sets a
+native-format capability, so ast_channel_nativeformats() returns NULL on
+such channels. When CHANNEL(audionativeformat) / CHANNEL(videonativeformat)
+is evaluated against a dummy channel (e.g. via ARI channelvars during a
+Stasis VarSet event raised while app_voicemail builds the notification
+email on a dummy channel), func_channel_read() passes that NULL straight
+into ast_format_cap_append_from_cap(), causing a NULL dereference at
+offset 0x28 and a SIGSEGV.
+
+Guard both helpers against a NULL source. A NULL source simply means
+"no formats to copy", so appending/replacing nothing is the correct
+no-op behaviour. This also protects all other callers.
+
+Reproduced on Asterisk 22.10.0.
+---
+ main/format_cap.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+Index: asterisk-22.10.0/main/format_cap.c
+===================================================================
+--- asterisk-22.10.0.orig/main/format_cap.c
++++ asterisk-22.10.0/main/format_cap.c
+@@ -271,6 +271,10 @@ int ast_format_cap_append_from_cap(struc
+ {
+ 	int idx, res = 0;
+ 
++	if (!src) {
++		return 0;
++	}
++
+ 	/* NOTE:  The streams API is dependent on the formats being in "preference" order */
+ 	for (idx = 0; (idx < AST_VECTOR_SIZE(&src->preference_order)) && !res; ++idx) {
+ 		struct format_cap_framed *framed = AST_VECTOR_GET(&src->preference_order, idx);
+@@ -308,6 +312,10 @@ void ast_format_cap_replace_from_cap(str
+ {
+ 	int idx;
+ 
++	if (!src) {
++		return;
++	}
++
+ 	for (idx = 0; (idx < AST_VECTOR_SIZE(&src->preference_order)); ++idx) {
+ 		struct format_cap_framed *framed = AST_VECTOR_GET(&src->preference_order, idx);
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -27,3 +27,4 @@ mix_monitor_announce_file
 fix-application-playback-update
 expose-app-queues-mutex
 fix-queue-deadlock
+null-src-format-cap


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Fixes a core-media-path NULL dereference that can take down the Asterisk process; behavior change is limited to treating NULL src as a no-op when copying formats.
> 
> **Overview**
> Adds a Debian source patch **`null-src-format-cap`** so **`ast_format_cap_append_from_cap()`** and **`ast_format_cap_replace_from_cap()`** return early when **`src`** is NULL, instead of dereferencing **`src->preference_order`** and crashing.
> 
> This targets a **SIGSEGV** seen on Asterisk 22.10.0 when **`CHANNEL(audionativeformat)`** / **`CHANNEL(videonativeformat)`** is read on a dummy channel (NULL native formats)—for example during **ARI channelvars** / **Stasis VarSet** while **app_voicemail** builds notification email.
> 
> The patch is enabled in **`debian/patches/series`** and the package is bumped to **`8:22.10.0-1~wazo5`** in **`debian/changelog`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a18cca8e1d7f1b0c34a531fa23772e142aba04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->