### PR TITLE
[ITEM-419] update to asterisk 22.10.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.10.1-1~wazo2) wazo-dev-bookworm; urgency=medium
+
+  * asterisk 22.10.1
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 29 Jun 2026 10:00:00 -0400
+
 asterisk (8:22.10.0-1~wazo5) wazo-dev-bookworm; urgency=medium
 
   * add format_cap NULL dereference patch

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-22.10.0/contrib/scripts/astgenkey
+Index: asterisk-22.10.1/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-22.10.0.orig/contrib/scripts/astgenkey
-+++ asterisk-22.10.0/contrib/scripts/astgenkey
+--- asterisk-22.10.1.orig/contrib/scripts/astgenkey
++++ asterisk-22.10.1/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,10 +3,10 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-22.10.0/Makefile
+Index: asterisk-22.10.1/Makefile
 ===================================================================
---- asterisk-22.10.0.orig/Makefile
-+++ asterisk-22.10.0/Makefile
+--- asterisk-22.10.1.orig/Makefile
++++ asterisk-22.10.1/Makefile
 @@ -449,7 +449,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean

--- a/debian/patches/expose-app-queues-mutex
+++ b/debian/patches/expose-app-queues-mutex
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -2239,6 +2239,9 @@ static int op_value_get(struct op_value
  static void op_value_set(struct op_value *op_value, int value);
  static void op_value_undef(struct op_value *op_value);
@@ -33,10 +33,10 @@ Index: asterisk-22.10.0/apps/app_queue.c
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
  	.unload = unload_module,
-Index: asterisk-22.10.0/apps/app_queue.exports.in
+Index: asterisk-22.10.1/apps/app_queue.exports.in
 ===================================================================
 --- /dev/null
-+++ asterisk-22.10.0/apps/app_queue.exports.in
++++ asterisk-22.10.1/apps/app_queue.exports.in
 @@ -0,0 +1,6 @@
 +{
 +	global:

--- a/debian/patches/fix-application-playback-update
+++ b/debian/patches/fix-application-playback-update
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/res/res_stasis_playback.c
+Index: asterisk-22.10.1/res/res_stasis_playback.c
 ===================================================================
---- asterisk-22.10.0.orig/res/res_stasis_playback.c
-+++ asterisk-22.10.0/res/res_stasis_playback.c
+--- asterisk-22.10.1.orig/res/res_stasis_playback.c
++++ asterisk-22.10.1/res/res_stasis_playback.c
 @@ -344,7 +344,8 @@ static void play_on_channel(struct stasi
  			if (!recording) {
  				ast_log(LOG_ERROR, "Attempted to play recording '%s' on channel '%s' but recording does not exist",

--- a/debian/patches/fix-invalid-moh
+++ b/debian/patches/fix-invalid-moh
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/res/res_musiconhold.c
+Index: asterisk-22.10.1/res/res_musiconhold.c
 ===================================================================
---- asterisk-22.10.0.orig/res/res_musiconhold.c
-+++ asterisk-22.10.0/res/res_musiconhold.c
+--- asterisk-22.10.1.orig/res/res_musiconhold.c
++++ asterisk-22.10.1/res/res_musiconhold.c
 @@ -413,7 +413,9 @@ static int moh_files_next(struct ast_cha
  		state->samples = 0;
  	}

--- a/debian/patches/fix-queue-deadlock
+++ b/debian/patches/fix-queue-deadlock
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -2014,6 +2014,15 @@ struct skills_group {
  
  static AST_LIST_HEAD_STATIC(skills_groups, skills_group);
@@ -141,7 +141,7 @@ Index: asterisk-22.10.0/apps/app_queue.c
  
  	if ((cur = ao2_alloc(sizeof(*cur), destroy_queue_member_cb))) {
  		cur->ringinuse = ringinuse;
-@@ -3280,6 +3327,32 @@ static struct member *create_queue_membe
+@@ -3280,6 +3329,32 @@ static struct member *create_queue_membe
  			ast_copy_string(cur->skills, skills, sizeof(cur->skills));
  		else
  			cur->skills[0] = '\0';
@@ -548,7 +548,10 @@ Index: asterisk-22.10.0/apps/app_queue.c
  
  			ao2_link(q->members, newm);
  			ao2_unlink(q->members, cur);
-@@ -10777,7 +10979,8 @@ static void print_queue(struct mansessio
+@@ -10774,10 +10976,11 @@ static void print_queue(struct mansessio
+ 
+ 			ast_str_append(&out, 0, " (ringinuse %s)", mem->ringinuse ? "enabled" : "disabled");
+ 
 +			time_t starttime = get_starttime(mem);
  			ast_str_append(&out, 0, "%s%s%s%s%s%s%s%s%s",
  				mem->dynamic ? ast_term_color(COLOR_CYAN, COLOR_BLACK) : "", mem->dynamic ? " (dynamic)" : "", ast_term_reset(),
@@ -558,7 +561,7 @@ Index: asterisk-22.10.0/apps/app_queue.c
  
  			if (mem->paused) {
  				ast_str_append(&out, 0, " %s(paused%s%s was %ld secs ago)%s",
-@@ -10795,9 +10997,11 @@ static void print_queue(struct mansessio
+@@ -10795,9 +10998,11 @@ static void print_queue(struct mansessio
  					ast_devstate2str(mem->status), ast_term_reset());
  			if (!ast_strlen_zero(mem->skills))
  				ast_str_append(&out, 0, " (skills: %s)", mem->skills);
@@ -572,7 +575,7 @@ Index: asterisk-22.10.0/apps/app_queue.c
  			} else {
  				ast_str_append(&out, 0, " has taken no calls yet");
  			}
-@@ -11295,7 +11497,7 @@ static int manager_queues_status(struct
+@@ -11295,7 +11500,7 @@ static int manager_queues_status(struct
  						"%s"
  						"\r\n",
  						q->name, mem->membername, mem->interface, mem->state_interface, mem->dynamic ? "dynamic" : "static",
@@ -581,7 +584,7 @@ Index: asterisk-22.10.0/apps/app_queue.c
  						mem->paused, mem->reason_paused, mem->wrapuptime, mem->skills, idText);
  					++q_items;
  				}
-@@ -12394,17 +12596,16 @@ static int qupd_exec(struct ast_channel
+@@ -12394,17 +12599,16 @@ static int qupd_exec(struct ast_channel
  				if (!strcasecmp(args.status, "ANSWER")) {
  					oldtalktime = q->talktime;
  					q->talktime = (((oldtalktime << 2) - oldtalktime) + newtalktime) >> 2;

--- a/debian/patches/increase-max-sdp-media
+++ b/debian/patches/increase-max-sdp-media
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/third-party/pjproject/patches/config_site.h
+Index: asterisk-22.10.1/third-party/pjproject/patches/config_site.h
 ===================================================================
---- asterisk-22.10.0.orig/third-party/pjproject/patches/config_site.h
-+++ asterisk-22.10.0/third-party/pjproject/patches/config_site.h
+--- asterisk-22.10.1.orig/third-party/pjproject/patches/config_site.h
++++ asterisk-22.10.1/third-party/pjproject/patches/config_site.h
 @@ -87,7 +87,7 @@
  #define	PJMEDIA_MAX_SDP_FMT   72
  #define	PJMEDIA_MAX_SDP_BANDW   4

--- a/debian/patches/mix_monitor_announce_file
+++ b/debian/patches/mix_monitor_announce_file
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_mixmonitor.c
+Index: asterisk-22.10.1/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_mixmonitor.c
-+++ asterisk-22.10.0/apps/app_mixmonitor.c
+--- asterisk-22.10.1.orig/apps/app_mixmonitor.c
++++ asterisk-22.10.1/apps/app_mixmonitor.c
 @@ -147,10 +147,14 @@
  						<para>Stores the MixMonitor's ID on this channel variable.</para>
  					</option>

--- a/debian/patches/mixmonitor_close_beep_file
+++ b/debian/patches/mixmonitor_close_beep_file
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_mixmonitor.c
+Index: asterisk-22.10.1/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_mixmonitor.c
-+++ asterisk-22.10.0/apps/app_mixmonitor.c
+--- asterisk-22.10.1.orig/apps/app_mixmonitor.c
++++ asterisk-22.10.1/apps/app_mixmonitor.c
 @@ -945,7 +945,9 @@ frame_cleanup:
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {

--- a/debian/patches/null-src-format-cap
+++ b/debian/patches/null-src-format-cap
@@ -23,10 +23,10 @@ Reproduced on Asterisk 22.10.0.
  main/format_cap.c | 8 ++++++++
  1 file changed, 8 insertions(+)
 
-Index: asterisk-22.10.0/main/format_cap.c
+Index: asterisk-22.10.1/main/format_cap.c
 ===================================================================
---- asterisk-22.10.0.orig/main/format_cap.c
-+++ asterisk-22.10.0/main/format_cap.c
+--- asterisk-22.10.1.orig/main/format_cap.c
++++ asterisk-22.10.1/main/format_cap.c
 @@ -271,6 +271,10 @@ int ast_format_cap_append_from_cap(struc
  {
  	int idx, res = 0;

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-22.10.0/res/ari.make
+Index: asterisk-22.10.1/res/ari.make
 ===================================================================
---- asterisk-22.10.0.orig/res/ari.make
-+++ asterisk-22.10.0/res/ari.make
+--- asterisk-22.10.1.orig/res/ari.make
++++ asterisk-22.10.1/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-22.10.0/res/ari/resource_wazo.c
+Index: asterisk-22.10.1/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-22.10.0/res/ari/resource_wazo.c
++++ asterisk-22.10.1/res/ari/resource_wazo.c
 @@ -0,0 +1,417 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -429,10 +429,10 @@ Index: asterisk-22.10.0/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-22.10.0/res/ari/resource_wazo.h
+Index: asterisk-22.10.1/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-22.10.0/res/ari/resource_wazo.h
++++ asterisk-22.10.1/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -634,10 +634,10 @@ Index: asterisk-22.10.0/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-22.10.0/res/res_ari_wazo.c
+Index: asterisk-22.10.1/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-22.10.0/res/res_ari_wazo.c
++++ asterisk-22.10.1/res/res_ari_wazo.c
 @@ -0,0 +1,608 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1247,10 +1247,10 @@ Index: asterisk-22.10.0/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-22.10.0/rest-api/api-docs/wazo.json
+Index: asterisk-22.10.1/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-22.10.0/rest-api/api-docs/wazo.json
++++ asterisk-22.10.1/rest-api/api-docs/wazo.json
 @@ -0,0 +1,296 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1548,10 +1548,10 @@ Index: asterisk-22.10.0/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-22.10.0/rest-api/resources.json
+Index: asterisk-22.10.1/rest-api/resources.json
 ===================================================================
---- asterisk-22.10.0.orig/rest-api/resources.json
-+++ asterisk-22.10.0/rest-api/resources.json
+--- asterisk-22.10.1.orig/rest-api/resources.json
++++ asterisk-22.10.1/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1563,10 +1563,10 @@ Index: asterisk-22.10.0/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-22.10.0/include/asterisk/app.h
+Index: asterisk-22.10.1/include/asterisk/app.h
 ===================================================================
---- asterisk-22.10.0.orig/include/asterisk/app.h
-+++ asterisk-22.10.0/include/asterisk/app.h
+--- asterisk-22.10.1.orig/include/asterisk/app.h
++++ asterisk-22.10.1/include/asterisk/app.h
 @@ -518,6 +518,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1656,10 +1656,10 @@ Index: asterisk-22.10.0/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-22.10.0/main/app.c
+Index: asterisk-22.10.1/main/app.c
 ===================================================================
---- asterisk-22.10.0.orig/main/app.c
-+++ asterisk-22.10.0/main/app.c
+--- asterisk-22.10.1.orig/main/app.c
++++ asterisk-22.10.1/main/app.c
 @@ -736,6 +736,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1719,10 +1719,10 @@ Index: asterisk-22.10.0/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-22.10.0/apps/app_voicemail.c
+Index: asterisk-22.10.1/apps/app_voicemail.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_voicemail.c
-+++ asterisk-22.10.0/apps/app_voicemail.c
+--- asterisk-22.10.1.orig/apps/app_voicemail.c
++++ asterisk-22.10.1/apps/app_voicemail.c
 @@ -713,6 +713,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
@@ -1957,10 +1957,10 @@ Index: asterisk-22.10.0/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-22.10.0/main/http.c
+Index: asterisk-22.10.1/main/http.c
 ===================================================================
---- asterisk-22.10.0.orig/main/http.c
-+++ asterisk-22.10.0/main/http.c
+--- asterisk-22.10.1.orig/main/http.c
++++ asterisk-22.10.1/main/http.c
 @@ -83,7 +83,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */
@@ -1970,10 +1970,10 @@ Index: asterisk-22.10.0/main/http.c
  #else
  #define MAX_CONTENT_LENGTH 1024
  #endif	/* !defined(LOW_MEMORY) */
-Index: asterisk-22.10.0/res/ari/ari_model_validators.c
+Index: asterisk-22.10.1/res/ari/ari_model_validators.c
 ===================================================================
---- asterisk-22.10.0.orig/res/ari/ari_model_validators.c
-+++ asterisk-22.10.0/res/ari/ari_model_validators.c
+--- asterisk-22.10.1.orig/res/ari/ari_model_validators.c
++++ asterisk-22.10.1/res/ari/ari_model_validators.c
 @@ -9027,3 +9027,41 @@ ari_validator ast_ari_validate_applicati
  {
  	return ast_ari_validate_application;
@@ -2016,10 +2016,10 @@ Index: asterisk-22.10.0/res/ari/ari_model_validators.c
 +{
 +	return ast_ari_validate_encoded_file;
 +}
-Index: asterisk-22.10.0/res/ari/ari_model_validators.h
+Index: asterisk-22.10.1/res/ari/ari_model_validators.h
 ===================================================================
---- asterisk-22.10.0.orig/res/ari/ari_model_validators.h
-+++ asterisk-22.10.0/res/ari/ari_model_validators.h
+--- asterisk-22.10.1.orig/res/ari/ari_model_validators.h
++++ asterisk-22.10.1/res/ari/ari_model_validators.h
 @@ -1551,6 +1551,22 @@ int ast_ari_validate_application(struct
   */
  ari_validator ast_ari_validate_application_fn(void);

--- a/debian/patches/wazo_banner
+++ b/debian/patches/wazo_banner
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/main/asterisk.c
+Index: asterisk-22.10.1/main/asterisk.c
 ===================================================================
---- asterisk-22.10.0.orig/main/asterisk.c
-+++ asterisk-22.10.0/main/asterisk.c
+--- asterisk-22.10.1.orig/main/asterisk.c
++++ asterisk-22.10.1/main/asterisk.c
 @@ -315,6 +315,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \

--- a/debian/patches/wazo_mixmonitor_events
+++ b/debian/patches/wazo_mixmonitor_events
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_mixmonitor.c
+Index: asterisk-22.10.1/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_mixmonitor.c
-+++ asterisk-22.10.0/apps/app_mixmonitor.c
+--- asterisk-22.10.1.orig/apps/app_mixmonitor.c
++++ asterisk-22.10.1/apps/app_mixmonitor.c
 @@ -1082,6 +1082,8 @@ static int launch_monitor_thread(struct
  	struct mixmonitor *mixmonitor;
  	char postprocess2[1024] = "";
@@ -91,10 +91,10 @@ Index: asterisk-22.10.0/apps/app_mixmonitor.c
  	return 0;
  }
  
-Index: asterisk-22.10.0/main/cel.c
+Index: asterisk-22.10.1/main/cel.c
 ===================================================================
---- asterisk-22.10.0.orig/main/cel.c
-+++ asterisk-22.10.0/main/cel.c
+--- asterisk-22.10.1.orig/main/cel.c
++++ asterisk-22.10.1/main/cel.c
 @@ -344,6 +344,8 @@ static const char * const cel_event_type
  	[AST_CEL_STREAM_BEGIN]     = "STREAM_BEGIN",
  	[AST_CEL_STREAM_END]       = "STREAM_END",
@@ -155,10 +155,10 @@ Index: asterisk-22.10.0/main/cel.c
  		ast_local_optimization_end_type(),
  		cel_local_optimization_end_cb,
  		NULL);
-Index: asterisk-22.10.0/include/asterisk/cel.h
+Index: asterisk-22.10.1/include/asterisk/cel.h
 ===================================================================
---- asterisk-22.10.0.orig/include/asterisk/cel.h
-+++ asterisk-22.10.0/include/asterisk/cel.h
+--- asterisk-22.10.1.orig/include/asterisk/cel.h
++++ asterisk-22.10.1/include/asterisk/cel.h
 @@ -84,6 +84,10 @@ enum ast_cel_event_type {
  	AST_CEL_STREAM_END = 20,
  	/*! \brief A DTMF digit was processed */

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/res/res_pjsip/location.c
+Index: asterisk-22.10.1/res/res_pjsip/location.c
 ===================================================================
---- asterisk-22.10.0.orig/res/res_pjsip/location.c
-+++ asterisk-22.10.0/res/res_pjsip/location.c
+--- asterisk-22.10.1.orig/res/res_pjsip/location.c
++++ asterisk-22.10.1/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,10 +41,10 @@ Index: asterisk-22.10.0/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-22.10.0/res/res_pjsip_registrar.c
+Index: asterisk-22.10.1/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-22.10.0.orig/res/res_pjsip_registrar.c
-+++ asterisk-22.10.0/res/res_pjsip_registrar.c
+--- asterisk-22.10.1.orig/res/res_pjsip_registrar.c
++++ asterisk-22.10.1/res/res_pjsip_registrar.c
 @@ -625,6 +625,35 @@ static int vec_contact_add(void *obj, vo
  	return 0;
  }
@@ -190,10 +190,10 @@ Index: asterisk-22.10.0/res/res_pjsip_registrar.c
  	response_contact = ao2_callback(contacts, 0, NULL, NULL);
  
  	/* Send a response containing all of the contacts (including static) that are present on this AOR */
-Index: asterisk-22.10.0/include/asterisk/res_pjsip.h
+Index: asterisk-22.10.1/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-22.10.0.orig/include/asterisk/res_pjsip.h
-+++ asterisk-22.10.0/include/asterisk/res_pjsip.h
+--- asterisk-22.10.1.orig/include/asterisk/res_pjsip.h
++++ asterisk-22.10.1/include/asterisk/res_pjsip.h
 @@ -409,6 +409,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
@@ -212,10 +212,10 @@ Index: asterisk-22.10.0/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-22.10.0/res/res_pjsip/pjsip_config.xml
+Index: asterisk-22.10.1/res/res_pjsip/pjsip_config.xml
 ===================================================================
---- asterisk-22.10.0.orig/res/res_pjsip/pjsip_config.xml
-+++ asterisk-22.10.0/res/res_pjsip/pjsip_config.xml
+--- asterisk-22.10.1.orig/res/res_pjsip/pjsip_config.xml
++++ asterisk-22.10.1/res/res_pjsip/pjsip_config.xml
 @@ -2780,6 +2780,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -2568,6 +2568,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -6584,7 +6584,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/main/stasis_channels.c
+Index: asterisk-22.10.1/main/stasis_channels.c
 ===================================================================
---- asterisk-22.10.0.orig/main/stasis_channels.c
-+++ asterisk-22.10.0/main/stasis_channels.c
+--- asterisk-22.10.1.orig/main/stasis_channels.c
++++ asterisk-22.10.1/main/stasis_channels.c
 @@ -1827,6 +1827,47 @@ struct ast_ari_transfer_message *ast_ari
  	return msg;
  }
@@ -65,10 +65,10 @@ Index: asterisk-22.10.0/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_mute_type);
-Index: asterisk-22.10.0/rest-api/api-docs/events.json
+Index: asterisk-22.10.1/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-22.10.0.orig/rest-api/api-docs/events.json
-+++ asterisk-22.10.0/rest-api/api-docs/events.json
+--- asterisk-22.10.1.orig/rest-api/api-docs/events.json
++++ asterisk-22.10.1/rest-api/api-docs/events.json
 @@ -251,7 +251,9 @@
  				"ChannelTransfer",
  				"RESTResponse",
@@ -114,10 +114,10 @@ Index: asterisk-22.10.0/rest-api/api-docs/events.json
  		}
  	}
  }
-Index: asterisk-22.10.0/res/ari/ari_model_validators.c
+Index: asterisk-22.10.1/res/ari/ari_model_validators.c
 ===================================================================
---- asterisk-22.10.0.orig/res/ari/ari_model_validators.c
-+++ asterisk-22.10.0/res/ari/ari_model_validators.c
+--- asterisk-22.10.1.orig/res/ari/ari_model_validators.c
++++ asterisk-22.10.1/res/ari/ari_model_validators.c
 @@ -5115,6 +5115,212 @@ ari_validator ast_ari_validate_channel_l
  	return ast_ari_validate_channel_left_bridge;
  }
@@ -357,10 +357,10 @@ Index: asterisk-22.10.0/res/ari/ari_model_validators.c
  	if (strcmp("ChannelStateChange", discriminator) == 0) {
  		return ast_ari_validate_channel_state_change(json);
  	} else
-Index: asterisk-22.10.0/res/ari/ari_model_validators.h
+Index: asterisk-22.10.1/res/ari/ari_model_validators.h
 ===================================================================
---- asterisk-22.10.0.orig/res/ari/ari_model_validators.h
-+++ asterisk-22.10.0/res/ari/ari_model_validators.h
+--- asterisk-22.10.1.orig/res/ari/ari_model_validators.h
++++ asterisk-22.10.1/res/ari/ari_model_validators.h
 @@ -960,6 +960,38 @@ int ast_ari_validate_channel_left_bridge
  ari_validator ast_ari_validate_channel_left_bridge_fn(void);
  

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/res/ari/resource_channels.c
+Index: asterisk-22.10.1/res/ari/resource_channels.c
 ===================================================================
---- asterisk-22.10.0.orig/res/ari/resource_channels.c
-+++ asterisk-22.10.0/res/ari/resource_channels.c
+--- asterisk-22.10.1.orig/res/ari/resource_channels.c
++++ asterisk-22.10.1/res/ari/resource_channels.c
 @@ -1786,6 +1786,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-22.10.0/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-22.10.0/res/ari/resource_channels.h
+Index: asterisk-22.10.1/res/ari/resource_channels.h
 ===================================================================
---- asterisk-22.10.0.orig/res/ari/resource_channels.h
-+++ asterisk-22.10.0/res/ari/resource_channels.h
+--- asterisk-22.10.1.orig/res/ari/resource_channels.h
++++ asterisk-22.10.1/res/ari/resource_channels.h
 @@ -708,6 +708,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *value;
  	/*! Whether this variable should be included in channel events. Defaults to false. */
@@ -37,10 +37,10 @@ Index: asterisk-22.10.0/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-22.10.0/res/res_ari_channels.c
+Index: asterisk-22.10.1/res/res_ari_channels.c
 ===================================================================
---- asterisk-22.10.0.orig/res/res_ari_channels.c
-+++ asterisk-22.10.0/res/res_ari_channels.c
+--- asterisk-22.10.1.orig/res/res_ari_channels.c
++++ asterisk-22.10.1/res/res_ari_channels.c
 @@ -2488,6 +2488,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->report_events = ast_json_is_true(field);
@@ -62,10 +62,10 @@ Index: asterisk-22.10.0/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-22.10.0/rest-api/api-docs/channels.json
+Index: asterisk-22.10.1/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-22.10.0.orig/rest-api/api-docs/channels.json
-+++ asterisk-22.10.0/rest-api/api-docs/channels.json
+--- asterisk-22.10.1.orig/rest-api/api-docs/channels.json
++++ asterisk-22.10.1/rest-api/api-docs/channels.json
 @@ -1610,6 +1610,15 @@
  							"allowMultiple": false,
  							"dataType": "boolean",

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/main/ccss.c
+Index: asterisk-22.10.1/main/ccss.c
 ===================================================================
---- asterisk-22.10.0.orig/main/ccss.c
-+++ asterisk-22.10.0/main/ccss.c
+--- asterisk-22.10.1.orig/main/ccss.c
++++ asterisk-22.10.1/main/ccss.c
 @@ -2698,6 +2698,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/include/asterisk/channel.h
+Index: asterisk-22.10.1/include/asterisk/channel.h
 ===================================================================
---- asterisk-22.10.0.orig/include/asterisk/channel.h
-+++ asterisk-22.10.0/include/asterisk/channel.h
+--- asterisk-22.10.1.orig/include/asterisk/channel.h
++++ asterisk-22.10.1/include/asterisk/channel.h
 @@ -4522,6 +4522,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
@@ -21,10 +21,10 @@ Index: asterisk-22.10.0/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-22.10.0/main/channel.c
+Index: asterisk-22.10.1/main/channel.c
 ===================================================================
---- asterisk-22.10.0.orig/main/channel.c
-+++ asterisk-22.10.0/main/channel.c
+--- asterisk-22.10.1.orig/main/channel.c
++++ asterisk-22.10.1/main/channel.c
 @@ -11211,3 +11211,34 @@ void ast_channel_clear_flag(struct ast_c
  	ast_channel_unlock(chan);
  }

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/main/features.c
+Index: asterisk-22.10.1/main/features.c
 ===================================================================
---- asterisk-22.10.0.orig/main/features.c
-+++ asterisk-22.10.0/main/features.c
+--- asterisk-22.10.1.orig/main/features.c
++++ asterisk-22.10.1/main/features.c
 @@ -644,6 +644,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/include/asterisk/file.h
+Index: asterisk-22.10.1/include/asterisk/file.h
 ===================================================================
---- asterisk-22.10.0.orig/include/asterisk/file.h
-+++ asterisk-22.10.0/include/asterisk/file.h
+--- asterisk-22.10.1.orig/include/asterisk/file.h
++++ asterisk-22.10.1/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,10 +10,10 @@ Index: asterisk-22.10.0/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-22.10.0/main/bridge_basic.c
+Index: asterisk-22.10.1/main/bridge_basic.c
 ===================================================================
---- asterisk-22.10.0.orig/main/bridge_basic.c
-+++ asterisk-22.10.0/main/bridge_basic.c
+--- asterisk-22.10.1.orig/main/bridge_basic.c
++++ asterisk-22.10.1/main/bridge_basic.c
 @@ -3222,7 +3222,7 @@ static int grab_transfer(struct ast_chan
  
  	/* Play the simple "transfer" prompt out and wait */

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,8 +1,8 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -10807,6 +10807,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -1898,6 +1898,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -4724,7 +4724,7 @@ static int say_position(struct queue_ent
  		}
  

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -6938,10 +6938,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/main/channel.c
+Index: asterisk-22.10.1/main/channel.c
 ===================================================================
---- asterisk-22.10.0.orig/main/channel.c
-+++ asterisk-22.10.0/main/channel.c
+--- asterisk-22.10.1.orig/main/channel.c
++++ asterisk-22.10.1/main/channel.c
 @@ -4923,7 +4923,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,7 +1,7 @@
-Index: asterisk-22.10.0/apps/app_queue.c
+Index: asterisk-22.10.1/apps/app_queue.c
 ===================================================================
---- asterisk-22.10.0.orig/apps/app_queue.c
-+++ asterisk-22.10.0/apps/app_queue.c
+--- asterisk-22.10.1.orig/apps/app_queue.c
++++ asterisk-22.10.1/apps/app_queue.c
 @@ -1714,6 +1714,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
@@ -2226,10 +2226,10 @@ Index: asterisk-22.10.0/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-22.10.0/configs/samples/queueskillrules.conf.sample
+Index: asterisk-22.10.1/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-22.10.0/configs/samples/queueskillrules.conf.sample
++++ asterisk-22.10.1/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2294,10 +2294,10 @@ Index: asterisk-22.10.0/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-22.10.0/configs/samples/queueskills.conf.sample
+Index: asterisk-22.10.1/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-22.10.0/configs/samples/queueskills.conf.sample
++++ asterisk-22.10.1/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
Lots of security issues have been fixed upstream on 22.10.1. 
Also includes crash on voicemail email patch from us, since it was not merged on time for 22.10.1.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major telephony core version upgrade with dozens of custom patches on queue, SIP, ARI, and voicemail; wide blast radius even when diffs are mostly rebases.
> 
> **Overview**
> Bumps the Wazo Debian package to **Asterisk 22.10.1** (`8:22.10.1-1~wazo2`) and rebases the full downstream patch queue onto the new upstream tree (patch hunks retargeted from `asterisk-22.10.0` to `asterisk-22.10.1`).
> 
> This release picks up **upstream 22.10.1** changes, including security fixes noted in the PR. The existing Wazo/Xivo customizations are carried forward unchanged in substance—queue shared-member stats, ARI Wazo voicemail APIs, PJSIP mobility, MixMonitor CEL/events, MOH/stasis fixes, and the **`format_cap` NULL `src` guard** for the voicemail notification email crash path.
> 
> No new patch logic appears in the diff beyond rebasing; regression risk is mainly **22.10.0 → 22.10.1** interaction with that large patch set on a production PBX core.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18aa471887c10fb7d3694501bf30bf43d41effa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->