### PR TITLE
ITEM-450 Inject X-Wazo-Call-ID in INVITE request/response

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.10.1-1~wazo3) wazo-dev-bookworm; urgency=medium
+
+  * add res_pjsip_wazo_call_id patch (X-Wazo-Call-ID header)
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 07 Jul 2026 14:25:59 -0400
+
 asterisk (8:22.10.1-1~wazo2) wazo-dev-bookworm; urgency=medium
 
   * asterisk 22.10.1

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -28,3 +28,4 @@ fix-application-playback-update
 expose-app-queues-mutex
 fix-queue-deadlock
 null-src-format-cap
+wazo-res-pjsip-wazo-call-id

--- a/debian/patches/wazo-res-pjsip-wazo-call-id
+++ b/debian/patches/wazo-res-pjsip-wazo-call-id
@@ -2,7 +2,7 @@ Index: asterisk-22.10.1/res/res_pjsip_wazo_call_id.c
 ===================================================================
 --- /dev/null
 +++ asterisk-22.10.1/res/res_pjsip_wazo_call_id.c
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,94 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
 + *
@@ -35,12 +35,12 @@ Index: asterisk-22.10.1/res/res_pjsip_wazo_call_id.c
 +#include "asterisk/strings.h"
 +
 +/*
-+ * Adds the channel uniqueid to INVITE responses (180/183/200) as
-+ * X-Wazo-Call-ID so SIP clients learn the Wazo call id of their own leg
-+ * in-band, without having to fetch it from the REST API.
++ * Adds the channel uniqueid as X-Wazo-Call-ID to the INVITEs Asterisk sends
++ * and to INVITE responses (180/183/200), so SIP clients learn the Wazo call
++ * id of their own leg in-band, without having to fetch it from the REST API.
 + */
 +
-+static void wazo_call_id_outgoing_response(struct ast_sip_session *session, pjsip_tx_data *tdata)
++static void add_wazo_call_id_header(struct ast_sip_session *session, pjsip_tx_data *tdata)
 +{
 +	static const pj_str_t hdr_name = { "X-Wazo-Call-ID", 14 };
 +	char uniqueid[AST_MAX_UNIQUEID];
@@ -61,9 +61,20 @@ Index: asterisk-22.10.1/res/res_pjsip_wazo_call_id.c
 +	ast_sip_add_header(tdata, "X-Wazo-Call-ID", uniqueid);
 +}
 +
++static void wazo_call_id_outgoing_request(struct ast_sip_session *session, pjsip_tx_data *tdata)
++{
++	add_wazo_call_id_header(session, tdata);
++}
++
++static void wazo_call_id_outgoing_response(struct ast_sip_session *session, pjsip_tx_data *tdata)
++{
++	add_wazo_call_id_header(session, tdata);
++}
++
 +static struct ast_sip_session_supplement wazo_call_id_supplement = {
 +	.method = "INVITE",
 +	.priority = AST_SIP_SUPPLEMENT_PRIORITY_CHANNEL,
++	.outgoing_request = wazo_call_id_outgoing_request,
 +	.outgoing_response = wazo_call_id_outgoing_response,
 +};
 +

--- a/debian/patches/wazo-res-pjsip-wazo-call-id
+++ b/debian/patches/wazo-res-pjsip-wazo-call-id
@@ -1,0 +1,88 @@
+Index: asterisk-22.10.1/res/res_pjsip_wazo_call_id.c
+===================================================================
+--- /dev/null
++++ asterisk-22.10.1/res/res_pjsip_wazo_call_id.c
+@@ -0,0 +1,83 @@
++/*
++ * Asterisk -- An open source telephony toolkit.
++ *
++ * Copyright (C) 2026, The Wazo Authors (see the AUTHORS file)
++ *
++ * See http://www.asterisk.org for more information about
++ * the Asterisk project.
++ *
++ * This program is free software, distributed under the terms of
++ * the GNU General Public License Version 2. See the LICENSE file
++ * at the top of the source tree.
++ */
++
++/*** MODULEINFO
++	<depend>pjproject</depend>
++	<depend>res_pjsip</depend>
++	<depend>res_pjsip_session</depend>
++	<support_level>extended</support_level>
++ ***/
++
++#include "asterisk.h"
++
++#include <pjsip.h>
++#include <pjsip_ua.h>
++
++#include "asterisk/res_pjsip.h"
++#include "asterisk/res_pjsip_session.h"
++#include "asterisk/module.h"
++#include "asterisk/channel.h"
++#include "asterisk/strings.h"
++
++/*
++ * Adds the channel uniqueid to INVITE responses (180/183/200) as
++ * X-Wazo-Call-ID so SIP clients learn the Wazo call id of their own leg
++ * in-band, without having to fetch it from the REST API.
++ */
++
++static void wazo_call_id_outgoing_response(struct ast_sip_session *session, pjsip_tx_data *tdata)
++{
++	static const pj_str_t hdr_name = { "X-Wazo-Call-ID", 14 };
++	char uniqueid[AST_MAX_UNIQUEID];
++
++	if (!session->channel) {
++		return;
++	}
++
++	/* The same tdata can go through the supplement more than once */
++	if (pjsip_msg_find_hdr_by_name(tdata->msg, &hdr_name, NULL)) {
++		return;
++	}
++
++	ast_channel_lock(session->channel);
++	ast_copy_string(uniqueid, ast_channel_uniqueid(session->channel), sizeof(uniqueid));
++	ast_channel_unlock(session->channel);
++
++	ast_sip_add_header(tdata, "X-Wazo-Call-ID", uniqueid);
++}
++
++static struct ast_sip_session_supplement wazo_call_id_supplement = {
++	.method = "INVITE",
++	.priority = AST_SIP_SUPPLEMENT_PRIORITY_CHANNEL,
++	.outgoing_response = wazo_call_id_outgoing_response,
++};
++
++static int load_module(void)
++{
++	ast_sip_session_register_supplement(&wazo_call_id_supplement);
++	return AST_MODULE_LOAD_SUCCESS;
++}
++
++static int unload_module(void)
++{
++	ast_sip_session_unregister_supplement(&wazo_call_id_supplement);
++	return 0;
++}
++
++AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "PJSIP Wazo Call-ID header",
++	.support_level = AST_MODULE_SUPPORT_EXTENDED,
++	.load = load_module,
++	.unload = unload_module,
++	.load_pri = AST_MODPRI_APP_DEPEND,
++	.requires = "res_pjsip,res_pjsip_session",
++);


### PR DESCRIPTION
Why: expose the channel uniqueid to SIP clients in-band as an
X-Wazo-Call-ID header on INVITE responses (180/183/200), so they
can learn their own leg's Wazo call id without querying the REST
API.

Manually tested: start sngrep; desktop phone call *10, then receive 180 with X-Wazo-Call-ID, then query wazo-calld API with this ID and it works


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live SIP signaling on all INVITE legs and exposes internal call identifiers to peers; scope is limited to a small additive module using standard session supplements.
> 
> **Overview**
> Adds a Wazo Asterisk packaging patch that ships a new **`res_pjsip_wazo_call_id`** PJSIP session module, wired into **`debian/patches/series`** with a changelog bump.
> 
> The module registers an INVITE-only session supplement that sets **`X-Wazo-Call-ID`** to the channel **uniqueid** on **outgoing INVITE requests** and **outgoing INVITE responses** (e.g. 180/183/200), with a guard so the header is not duplicated if the same message is processed twice. SIP endpoints can read the Wazo call id for their leg from signaling instead of relying on a REST lookup.
> 
> Packaging-only change in this repo (patch file + series + changelog); behavior lives in the added C module applied at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21296cc824c9a2b1ae008c1daab24789c5139d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->