### PR TITLE
add func_channel NULL tech dereference patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.10.1-1~wazo4) wazo-dev-bookworm; urgency=medium
+
+  * add func_channel NULL tech dereference patch
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 22 Jul 2026 09:31:39 -0400
+
 asterisk (8:22.10.1-1~wazo3) wazo-dev-bookworm; urgency=medium
 
   * add res_pjsip_wazo_call_id patch (X-Wazo-Call-ID header)

--- a/debian/patches/null-tech-func-channel
+++ b/debian/patches/null-tech-func-channel
@@ -1,0 +1,62 @@
+From: Wazo Support <support@wazo.io>
+Date: Wed, 22 Jul 2026 00:00:00 +0000
+Subject: [PATCH] func_channel: guard against NULL tech on dummy channels
+
+func_channel_read() dereferences ast_channel_tech(chan)->type for
+CHANNEL(channeltype) without checking the tech for NULL.
+
+A dummy channel allocated with ast_dummy_channel_alloc() never sets a
+channel technology, so ast_channel_tech() returns NULL on such channels.
+When CHANNEL(channeltype) is evaluated against a dummy channel (e.g. via
+ARI channelvars during a Stasis VarSet event raised while app_voicemail
+builds the notification email on a dummy channel in prep_email_sub_vars),
+func_channel_read() dereferences the NULL tech pointer, causing a SIGSEGV
+in func_channel.c:465 on every voicemail deposit.
+
+Return an empty string for channeltype on a tech-less channel, matching
+the "nothing to report" no-op behaviour of the existing NULL guards in
+the read fallthrough (func_channel.c:609) and the pjsip item.
+
+Also guard the func_channel_write() fallthrough, which has the same
+unguarded ast_channel_tech(chan)->func_channel_write dereference and
+would crash the same way on a write to an unknown item.
+
+Same failure family as the null-src-format-cap patch (which fixed
+CHANNEL(audionativeformat)/CHANNEL(videonativeformat) for the same
+dummy-channel path in main/format_cap.c).
+
+Reproduced on Asterisk 22.10.1: incall -> user with WebRTC line ->
+forward to voicemail -> message deposited -> SIGSEGV in
+func_channel_read (LWP of the caller channel PBX thread), with
+CHANNEL(channeltype) present in ari.conf channelvars. The voicemail
+user must have an email address configured on the voicemail box, as
+the crash happens while building the email notification.
+---
+ funcs/func_channel.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+Index: asterisk-22.10.1/funcs/func_channel.c
+===================================================================
+--- asterisk-22.10.1.orig/funcs/func_channel.c
++++ asterisk-22.10.1/funcs/func_channel.c
+@@ -462,7 +462,9 @@ static int func_channel_read(struct ast_
+ 		locked_copy_string(chan, buf,
+ 			ast_channel_hold_state(chan) == AST_CONTROL_HOLD ? "1" : "0", len);
+ 	} else if (!strcasecmp(data, "channeltype"))
+-		locked_copy_string(chan, buf, ast_channel_tech(chan)->type, len);
++		locked_copy_string(chan, buf,
++			(ast_channel_tech(chan) && ast_channel_tech(chan)->type)
++				? ast_channel_tech(chan)->type : "", len);
+ 	else if (!strcasecmp(data, "accountcode"))
+ 		locked_copy_string(chan, buf, ast_channel_accountcode(chan), len);
+ 	else if (!strcasecmp(data, "checkhangup")) {
+@@ -797,7 +799,8 @@ static int func_channel_write_real(struc
+ 		}
+ 	} else if (!strcasecmp(data, "tenantid")) {
+ 		ast_channel_tenantid_set(chan, value);
+-	} else if (!ast_channel_tech(chan)->func_channel_write
++	} else if (!ast_channel_tech(chan)
++		 || !ast_channel_tech(chan)->func_channel_write
+ 		 || ast_channel_tech(chan)->func_channel_write(chan, function, data, value)) {
+ 		ast_log(LOG_WARNING, "Unknown or unavailable item requested: '%s'\n",
+ 				data);

--- a/debian/patches/null-tech-func-channel
+++ b/debian/patches/null-tech-func-channel
@@ -60,3 +60,25 @@ Index: asterisk-22.10.1/funcs/func_channel.c
  		 || ast_channel_tech(chan)->func_channel_write(chan, function, data, value)) {
  		ast_log(LOG_WARNING, "Unknown or unavailable item requested: '%s'\n",
  				data);
+Index: asterisk-22.10.1/main/channel.c
+===================================================================
+--- asterisk-22.10.1.orig/main/channel.c
++++ asterisk-22.10.1/main/channel.c
+@@ -7475,7 +7475,7 @@ int ast_channel_setoption(struct ast_cha
+ 	int res;
+ 
+ 	ast_channel_lock(chan);
+-	if (!ast_channel_tech(chan)->setoption) {
++	if (!ast_channel_tech(chan) || !ast_channel_tech(chan)->setoption) {
+ 		errno = ENOSYS;
+ 		ast_channel_unlock(chan);
+ 		return -1;
+@@ -7495,7 +7495,7 @@ int ast_channel_queryoption(struct ast_c
+ 	int res;
+ 
+ 	ast_channel_lock(chan);
+-	if (!ast_channel_tech(chan)->queryoption) {
++	if (!ast_channel_tech(chan) || !ast_channel_tech(chan)->queryoption) {
+ 		errno = ENOSYS;
+ 		ast_channel_unlock(chan);
+ 		return -1;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,3 +29,4 @@ expose-app-queues-mutex
 fix-queue-deadlock
 null-src-format-cap
 wazo-res-pjsip-wazo-call-id
+null-tech-func-channel


### PR DESCRIPTION
Why: CHANNEL(channeltype) in func_channel_read() dereferences
ast_channel_tech(chan)->type without a NULL check. Dummy channels
allocated with ast_dummy_channel_alloc() have no channel technology,
so when ari.conf channelvars contains CHANNEL(channeltype), the
Stasis VarSet snapshot raised while app_voicemail builds its email
notification (prep_email_sub_vars) evaluates it against the dummy
channel and Asterisk crashes with SIGSEGV on every voicemail deposit
for a mailbox with an email address configured. The crash also kills
the caller channel before its HANGUP/CHAN_END/LINKEDID_END CELs are
emitted, so wazo-call-logd never generates a CDR for the call.

The func_channel_write() fallthrough has the same unguarded
ast_channel_tech(chan)->func_channel_write dereference and is guarded
too, mirroring the existing NULL guard in the read fallthrough.

Same failure family as the format_cap NULL dereference patch
(CHANNEL(audionativeformat)/CHANNEL(videonativeformat), ~wazo5).

Manually tested: incall to a WebRTC user forwarded to voicemail with
an email address, message deposited; analyzed from coredump
core.1876520.1784666142 (22.10.1-1~wazo2, func_channel.c:465).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets core channel/func_channel paths on the PBX thread; fixes a production SIGSEGV on voicemail deposit but touches low-level Asterisk channel handling used broadly.
> 
> **Overview**
> Adds Debian patch **`null-tech-func-channel`** and bumps the package to **8:22.10.1-1~wazo4** to stop Asterisk from crashing when **`CHANNEL(channeltype)`** (or related channel func writes) runs on dummy channels with no channel technology.
> 
> **`func_channel_read`** now returns an empty string for **`channeltype`** when **`ast_channel_tech(chan)`** is NULL instead of dereferencing **`->type`**. **`func_channel_write`**’s tech dispatch path gets the same NULL check before calling **`func_channel_write`**.
> 
> **`ast_channel_setoption`** and **`ast_channel_queryoption`** in **`channel.c`** also bail out with **`ENOSYS`** if tech is NULL, avoiding the same class of SIGSEGV on tech-less channels (e.g. voicemail email prep with ARI **`channelvars`** during Stasis VarSet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6496e83916d6add5a0a933ab5c83b8323772152f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->