### PR TITLE
ITEM 494 review fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-asterisk (8:22.10.1-1~wazo4) wazo-dev-bookworm; urgency=medium
+asterisk (8:22.10.1-1~wazo5) wazo-dev-bookworm; urgency=medium
 
-  * add func_channel NULL tech dereference patch
+  * add func_channel/channel NULL tech dereference patch
 
  -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 22 Jul 2026 09:31:39 -0400
 

--- a/debian/patches/null-tech-func-channel
+++ b/debian/patches/null-tech-func-channel
@@ -21,6 +21,11 @@ Also guard the func_channel_write() fallthrough, which has the same
 unguarded ast_channel_tech(chan)->func_channel_write dereference and
 would crash the same way on a write to an unknown item.
 
+ast_channel_setoption() and ast_channel_queryoption() in main/channel.c
+dereference the tech unconditionally too; both already fail with ENOSYS
+when the tech provides no callback, so extend that same early return to
+a NULL tech.
+
 Same failure family as the null-src-format-cap patch (which fixed
 CHANNEL(audionativeformat)/CHANNEL(videonativeformat) for the same
 dummy-channel path in main/format_cap.c).
@@ -32,8 +37,9 @@ CHANNEL(channeltype) present in ari.conf channelvars. The voicemail
 user must have an email address configured on the voicemail box, as
 the crash happens while building the email notification.
 ---
- funcs/func_channel.c | 6 ++++--
- 1 file changed, 4 insertions(+), 2 deletions(-)
+ funcs/func_channel.c | 7 +++++--
+ main/channel.c       | 4 ++--
+ 2 files changed, 7 insertions(+), 4 deletions(-)
 
 Index: asterisk-22.10.1/funcs/func_channel.c
 ===================================================================


### PR DESCRIPTION
- **changelog: latest patch is for func_channel AND channel**
- **null-tech-func-channel patch: fix description to include channel.c changes**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Debian packaging changes; no new runtime code in this diff.
> 
> **Overview**
> **Review follow-up for the NULL tech dereference patch:** packaging metadata now matches the patch’s real scope (`funcs/func_channel.c` and `main/channel.c`), without changing the underlying fix in this diff.
> 
> The top **changelog** entry is retitled to mention **func_channel and channel**, and the Debian revision moves from `~wazo4` to `~wazo5`. The **`null-tech-func-channel`** patch header is expanded to document **`ast_channel_setoption()` / `ast_channel_queryoption()`** NULL-tech guards in `channel.c`, and the “files changed” blurb lists both files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f75c819552d52464b22877af9af3d7507fd97dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->